### PR TITLE
Fix Sentry build failures and ASM warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,7 +210,8 @@ sentry {
     org = "aurora-9i"
     projectName = "android"
 
-    def hasAuthToken = System.getenv("SENTRY_AUTH_TOKEN") != null
+    // 确保 SENTRY_AUTH_TOKEN 既不为 null 也不为空字符串
+    def hasAuthToken = (System.getenv("SENTRY_AUTH_TOKEN") ?: "").trim() != ""
 
     // this will upload your source code to Sentry to show it as part of the stack traces
     // disable if you don't want to expose your sources

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,6 +178,9 @@ dependencies {
     androidTestImplementation libs.androidx.compose.ui.test.junit4
     debugImplementation libs.androidx.compose.ui.tooling
     debugImplementation libs.androidx.compose.ui.test.manifest
+
+    // For Sentry ASM instrumentation to resolve window classes on some devices
+    compileOnly libs.androidx.window
 }
 
 tasks.register('buildRust', Exec) {
@@ -207,10 +210,16 @@ sentry {
     org = "aurora-9i"
     projectName = "android"
 
+    def hasAuthToken = System.getenv("SENTRY_AUTH_TOKEN") != null
+
     // this will upload your source code to Sentry to show it as part of the stack traces
     // disable if you don't want to expose your sources
-    includeSourceContext = true
+    includeSourceContext = hasAuthToken
 
     // CI 环境下如果没有 SENTRY_AUTH_TOKEN 则跳过上传，避免构建失败
-    autoUpload = System.getenv("SENTRY_AUTH_TOKEN") != null
+    autoUpload = hasAuthToken
+
+    // 禁用所有可能在没有 token 时导致失败的任务
+    uploadNativeSymbols = hasAuthToken
+    includeProguardMapping = hasAuthToken
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ provider = "0.1.70"
 accompanist-lyrics-ui = "1.0.19"
 accompanist-lyrics-core = "0.4.5"
 gaze-capsule = "2.1.1-patch2"
+androidx-window = "1.3.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -54,6 +55,7 @@ provider = { group = "io.github.proify.lyricon", name = "provider", version.ref 
 accompanist-lyrics-ui = { module = "com.mocharealm.accompanist:lyrics-ui", version.ref = "accompanist-lyrics-ui" }
 accompanist-lyrics-core = { module = "com.mocharealm.accompanist:lyrics-core", version.ref = "accompanist-lyrics-core" }
 gaze-capsule = { module = "com.mocharealm.gaze:capsule", version.ref = "gaze-capsule" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR addresses two issues in the build process:
1. **Sentry Authentication Failures (401):** The build was failing when trying to upload Proguard mappings and source bundles to Sentry without a valid token. I've updated `app/build.gradle` to explicitly disable these upload tasks if the `SENTRY_AUTH_TOKEN` environment variable is not set.
2. **ASM Instrumentation Warnings:** The Sentry plugin was reporting "unresolved classes" for `androidx.window` during its instrumentation phase. I've added `androidx.window:window` as a `compileOnly` dependency to resolve some of these warnings without adding to the final APK size. Note that some extension-specific classes may still report warnings due to missing public artifacts for those internal OEM interfaces.

---
*PR created automatically by Jules for task [12762936898726444830](https://jules.google.com/task/12762936898726444830) started by @Aurora-Nasa-1*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Sentry-related build failures by properly gating all upload tasks behind a null-and-empty-string-safe auth token check, and adds `androidx.window` as a `compileOnly` dependency to suppress ASM instrumentation warnings without bloating the APK.

- The `hasAuthToken` guard now uses `(System.getenv("SENTRY_AUTH_TOKEN") ?: "").trim() != ""`, correctly handling both a missing variable and an empty-string placeholder, and applies uniformly to `autoUpload`, `includeSourceContext`, `uploadNativeSymbols`, and `includeProguardMapping`.
- `androidx.window:window:1.3.0` is declared `compileOnly` so the Sentry bytecode instrumentation can resolve window classes at build time; because the library is almost certainly already present as a transitive dependency of Jetpack Compose and Navigation, no runtime `ClassNotFoundException` risk is introduced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped build-time fixes with no runtime behaviour changes.

The auth-token guard now correctly rejects null, missing, and empty-string values, closing the gap flagged in the previous review thread. The compileOnly window dependency is an established pattern for satisfying bytecode-instrumentation tools without shipping extra classes; since androidx.window is already a transitive dependency of the Compose and Navigation libraries used in this project, there is no risk of a runtime class-not-found error. No application logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/build.gradle | Adds compileOnly androidx.window dependency and gates all Sentry upload tasks behind a proper null+empty-string auth token check. |
| gradle/libs.versions.toml | Adds androidx.window 1.3.0 version entry and library alias to support the new compileOnly dependency in app/build.gradle. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Gradle configuration phase] --> B{SENTRY_AUTH_TOKEN set\nand non-empty?}
    B -- No --> C[hasAuthToken = false]
    B -- Yes --> D[hasAuthToken = true]
    C --> E[autoUpload = false\nincludeSourceContext = false\nuploadNativeSymbols = false\nincludeProguardMapping = false]
    D --> F[autoUpload = true\nincludeSourceContext = true\nuploadNativeSymbols = true\nincludeProguardMapping = true]
    E --> G[Build succeeds\nno Sentry uploads]
    F --> H[Build succeeds\nSentry artifacts uploaded]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Gradle configuration phase] --> B{SENTRY_AUTH_TOKEN set\nand non-empty?}
    B -- No --> C[hasAuthToken = false]
    B -- Yes --> D[hasAuthToken = true]
    C --> E[autoUpload = false\nincludeSourceContext = false\nuploadNativeSymbols = false\nincludeProguardMapping = false]
    D --> F[autoUpload = true\nincludeSourceContext = true\nuploadNativeSymbols = true\nincludeProguardMapping = true]
    E --> G[Build succeeds\nno Sentry uploads]
    F --> H[Build succeeds\nSentry artifacts uploaded]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: sentry upload failures and resolve ..."](https://github.com/aurora-nasa-1/cpplayer/commit/326c0597f8373a9ef1cb6e7092fa623ffb89b6f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38891079)</sub>

<!-- /greptile_comment -->