### PR TITLE
Fix DSP & Equalizer bugs and UI states

### DIFF
--- a/app/src/main/java/cp/player/engine/CPPlayerManager.kt
+++ b/app/src/main/java/cp/player/engine/CPPlayerManager.kt
@@ -15,6 +15,7 @@ object CPPlayerManager {
         return if (engineType == 1) {
             FlickPlayer(context)
         } else {
+            ExoAudioFxManager.initPrefs(context)
             val renderersFactory = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
 
             val dataSourceFactory = DataSourceFactoryProvider.createCacheDataSourceFactory(context)
@@ -28,8 +29,22 @@ object CPPlayerManager {
             val player = playerBuilder.build()
 
             player.addListener(object : Player.Listener {
+                private var currentSessionId: Int = 0
+
                 override fun onAudioSessionIdChanged(audioSessionId: Int) {
+                    if (currentSessionId != 0 && currentSessionId != audioSessionId) {
+                        ExoAudioFxManager.release(currentSessionId)
+                    }
+                    currentSessionId = audioSessionId
                     ExoAudioFxManager.init(audioSessionId)
+                }
+
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_IDLE && currentSessionId != 0) {
+                        // The player is stopped or released
+                        ExoAudioFxManager.release(currentSessionId)
+                        currentSessionId = 0
+                    }
                 }
             })
 

--- a/app/src/main/java/cp/player/engine/CrossfadeManager.kt
+++ b/app/src/main/java/cp/player/engine/CrossfadeManager.kt
@@ -83,6 +83,12 @@ class CrossfadeManager(
             old.pause()
             old.volume = 1.0f
             old.clearMediaItems()
+            if (old is ExoPlayer) {
+                val currentSessionId = old.audioSessionId
+                if (currentSessionId != 0 && currentSessionId != activePlayer?.audioSessionId) {
+                    ExoAudioFxManager.release(currentSessionId)
+                }
+            }
         }
         activePlayer?.volume = 1.0f
         isCrossfading = false
@@ -184,6 +190,12 @@ class CrossfadeManager(
             oldPlayer.pause()
             oldPlayer.volume = 1.0f
             oldPlayer.clearMediaItems()
+            if (oldPlayer is ExoPlayer) {
+                val currentSessionId = oldPlayer.audioSessionId
+                if (currentSessionId != 0 && currentSessionId != newPlayer.audioSessionId) {
+                    ExoAudioFxManager.release(currentSessionId)
+                }
+            }
 
             releaseAudioFx()
             isCrossfading = false

--- a/app/src/main/java/cp/player/engine/ExoAudioFxManager.kt
+++ b/app/src/main/java/cp/player/engine/ExoAudioFxManager.kt
@@ -4,24 +4,43 @@ import android.media.audiofx.Equalizer
 import android.media.audiofx.Virtualizer
 import android.util.Log
 
+import android.content.Context
+import cp.player.util.DspPreferences
+
 object ExoAudioFxManager {
     private const val TAG = "ExoAudioFxManager"
 
-    private var equalizer: Equalizer? = null
-    private var virtualizer: Virtualizer? = null
+    private data class SessionFx(
+        val equalizer: Equalizer?,
+        val virtualizer: Virtualizer?
+    )
+
+    private val activeSessions = mutableMapOf<Int, SessionFx>()
 
     // For preserving settings between sessions
     var eqEnabled = false
     private var internalVirtualizerEnabled = false
     val eqGains = mutableMapOf<Short, Short>() // band -> millibels
     private var internalVirtualizerStrength: Short = 0
+    private var isInitializedFromPrefs = false
+
+    fun initPrefs(context: Context) {
+        if (isInitializedFromPrefs) return
+        eqEnabled = DspPreferences.getExoEqEnabled(context)
+        internalVirtualizerEnabled = DspPreferences.getExoVirtualizerEnabled(context)
+        internalVirtualizerStrength = DspPreferences.getExoVirtualizerStrength(context)
+        eqGains.clear()
+        eqGains.putAll(DspPreferences.getExoEqGains(context))
+        isInitializedFromPrefs = true
+    }
 
     fun init(audioSessionId: Int) {
-        release()
         if (audioSessionId == 0) return
+        if (activeSessions.containsKey(audioSessionId)) return
 
+        var eq: Equalizer? = null
         try {
-            equalizer = Equalizer(0, audioSessionId).apply {
+            eq = Equalizer(0, audioSessionId).apply {
                 enabled = eqEnabled
                 for ((band, gain) in eqGains) {
                     if (band < numberOfBands) {
@@ -33,8 +52,9 @@ object ExoAudioFxManager {
             Log.e(TAG, "Failed to init Equalizer", e)
         }
 
+        var virt: Virtualizer? = null
         try {
-            virtualizer = Virtualizer(0, audioSessionId).apply {
+            virt = Virtualizer(0, audioSessionId).apply {
                 enabled = internalVirtualizerEnabled
                 if (internalVirtualizerStrength > 0) {
                     setStrength(internalVirtualizerStrength)
@@ -43,49 +63,73 @@ object ExoAudioFxManager {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to init Virtualizer", e)
         }
+
+        activeSessions[audioSessionId] = SessionFx(eq, virt)
     }
 
-    fun release() {
-        equalizer?.release()
-        equalizer = null
-        virtualizer?.release()
-        virtualizer = null
+    fun release(audioSessionId: Int) {
+        activeSessions.remove(audioSessionId)?.let { fx ->
+            fx.equalizer?.release()
+            fx.virtualizer?.release()
+        }
+    }
+
+    fun releaseAll() {
+        activeSessions.values.forEach { fx ->
+            fx.equalizer?.release()
+            fx.virtualizer?.release()
+        }
+        activeSessions.clear()
     }
 
     fun setEqualizerEnabled(enabled: Boolean) {
         eqEnabled = enabled
-        equalizer?.enabled = enabled
+        activeSessions.values.forEach { fx ->
+            fx.equalizer?.enabled = enabled
+        }
     }
 
     fun getEqualizerEnabled(): Boolean = eqEnabled
 
-    fun getNumberOfBands(): Short = equalizer?.numberOfBands ?: 0
+    fun getNumberOfBands(): Short {
+        return activeSessions.values.firstNotNullOfOrNull { it.equalizer }?.numberOfBands ?: 0
+    }
 
-    fun getCenterFreq(band: Short): Int = equalizer?.getCenterFreq(band) ?: 0
+    fun getCenterFreq(band: Short): Int {
+        return activeSessions.values.firstNotNullOfOrNull { it.equalizer }?.getCenterFreq(band) ?: 0
+    }
 
-    fun getBandLevelRange(): ShortArray = equalizer?.bandLevelRange ?: shortArrayOf(0, 0)
+    fun getBandLevelRange(): ShortArray {
+        return activeSessions.values.firstNotNullOfOrNull { it.equalizer }?.bandLevelRange ?: shortArrayOf(0, 0)
+    }
 
     fun setBandLevel(band: Short, level: Short) {
         eqGains[band] = level
-        if (equalizer != null && band < (equalizer?.numberOfBands ?: 0)) {
-            equalizer?.setBandLevel(band, level)
+        activeSessions.values.forEach { fx ->
+            if (fx.equalizer != null && band < fx.equalizer.numberOfBands) {
+                fx.equalizer.setBandLevel(band, level)
+            }
         }
     }
 
     fun getBandLevel(band: Short): Short {
-        return equalizer?.getBandLevel(band) ?: eqGains[band] ?: 0
+        return activeSessions.values.firstNotNullOfOrNull { it.equalizer }?.getBandLevel(band) ?: eqGains[band] ?: 0
     }
 
     fun setVirtualizerEnabled(enabled: Boolean) {
         internalVirtualizerEnabled = enabled
-        virtualizer?.enabled = enabled
+        activeSessions.values.forEach { fx ->
+            fx.virtualizer?.enabled = enabled
+        }
     }
 
     fun getVirtualizerEnabled(): Boolean = internalVirtualizerEnabled
 
     fun setVirtualizerStrength(strength: Short) {
         internalVirtualizerStrength = strength
-        virtualizer?.setStrength(strength)
+        activeSessions.values.forEach { fx ->
+            fx.virtualizer?.setStrength(strength)
+        }
     }
 
     fun getVirtualizerStrength(): Short = internalVirtualizerStrength

--- a/app/src/main/java/cp/player/engine/ExoAudioFxManager.kt
+++ b/app/src/main/java/cp/player/engine/ExoAudioFxManager.kt
@@ -64,7 +64,9 @@ object ExoAudioFxManager {
             Log.e(TAG, "Failed to init Virtualizer", e)
         }
 
-        activeSessions[audioSessionId] = SessionFx(eq, virt)
+        if (eq != null || virt != null) {
+            activeSessions[audioSessionId] = SessionFx(eq, virt)
+        }
     }
 
     fun release(audioSessionId: Int) {

--- a/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
@@ -28,7 +28,6 @@ import cp.player.util.PeqBand
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DspSettingsScreen(
     onNavigateBack: () -> Unit
@@ -36,15 +35,10 @@ fun DspSettingsScreen(
     val context = LocalContext.current
     val engineType = UserPreferences.getAudioEngine(context) // 0: ExoPlayer, 1: FlickPlayer
 
-    AppScaffold(
-        title = "DSP & Equalizer",
-        onBackPressed = onNavigateBack
-    ) { innerPadding ->
-        if (engineType == 0) {
-            ExoPlayerDspConfig(Modifier.padding(innerPadding))
-        } else {
-            FlickPlayerDspConfig(Modifier.padding(innerPadding))
-        }
+    if (engineType == 0) {
+        ExoPlayerDspConfig()
+    } else {
+        FlickPlayerDspConfig()
     }
 }
 

--- a/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
@@ -50,6 +50,9 @@ fun DspSettingsScreen(
 
 @Composable
 fun ExoPlayerDspConfig(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    ExoAudioFxManager.initPrefs(context)
+
     var eqEnabled by remember { mutableStateOf(ExoAudioFxManager.getEqualizerEnabled()) }
     var virtualizerEnabled by remember { mutableStateOf(ExoAudioFxManager.getVirtualizerEnabled()) }
     var virtualizerStrength by remember { mutableStateOf(ExoAudioFxManager.getVirtualizerStrength().toFloat()) }
@@ -86,6 +89,7 @@ fun ExoPlayerDspConfig(modifier: Modifier = Modifier) {
                     onCheckedChange = {
                         eqEnabled = it
                         ExoAudioFxManager.setEqualizerEnabled(it)
+                        DspPreferences.setExoEqEnabled(context, it)
                     }
                 )
             }
@@ -112,6 +116,7 @@ fun ExoPlayerDspConfig(modifier: Modifier = Modifier) {
                             val newLevel = it.toInt().toShort()
                             bandLevels[band] = newLevel
                             ExoAudioFxManager.setBandLevel(band, newLevel)
+                            DspPreferences.setExoEqGains(context, ExoAudioFxManager.eqGains)
                         },
                         valueRange = range[0].toFloat()..range[1].toFloat()
                     )
@@ -135,6 +140,7 @@ fun ExoPlayerDspConfig(modifier: Modifier = Modifier) {
                     onCheckedChange = {
                         virtualizerEnabled = it
                         ExoAudioFxManager.setVirtualizerEnabled(it)
+                        DspPreferences.setExoVirtualizerEnabled(context, it)
                     }
                 )
             }
@@ -149,6 +155,7 @@ fun ExoPlayerDspConfig(modifier: Modifier = Modifier) {
                         onValueChange = {
                             virtualizerStrength = it
                             ExoAudioFxManager.setVirtualizerStrength(it.toInt().toShort())
+                            DspPreferences.setExoVirtualizerStrength(context, it.toInt().toShort())
                         },
                         valueRange = 0f..1000f
                     )
@@ -177,6 +184,8 @@ fun FlickPlayerDspConfig(modifier: Modifier = Modifier) {
     var fxWidth by remember { mutableStateOf(DspPreferences.getFxWidth(context)) }
 
     fun applyRustEq() {
+        DspPreferences.setEqEnabled(context, eqEnabled)
+        DspPreferences.setPeqBands(context, peqBands.toList())
         if (peqBands.isEmpty()) {
             RustEngine.setEqualizer(eqEnabled, floatArrayOf(), floatArrayOf(), floatArrayOf())
             return

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -163,7 +163,7 @@ fun SettingsScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
+                    .then(if (screen != "dsp") Modifier.verticalScroll(rememberScrollState()) else Modifier)
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -108,7 +108,7 @@ fun SettingsScreen(
 
     var currentScreen by rememberSaveable { mutableStateOf("main") }
     // 子页面的父页面映射（debug 的子页面返回到 debug，其他返回到 main）
-    val parentScreen = mapOf("health" to "debug", "logViewer" to "debug", "providerTest" to "debug", "about" to "main")
+    val parentScreen = mapOf("health" to "debug", "logViewer" to "debug", "providerTest" to "debug", "about" to "main", "dsp" to "audio")
 
     val dirPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree()
@@ -843,6 +843,12 @@ fun SettingsScreen(
                     "logViewer" -> {
                         // 日志查看器 - 内嵌在设置中
                         cp.player.ui.screen.LogViewerInline()
+                    }
+                    "dsp" -> {
+                        // DSP & Equalizer
+                        cp.player.ui.screen.DspSettingsScreen(
+                            onNavigateBack = { currentScreen = parentScreen["dsp"] ?: "main" }
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.height(32.dp + bottomContentPadding.calculateBottomPadding()))

--- a/app/src/main/java/cp/player/util/AutoEqParser.kt
+++ b/app/src/main/java/cp/player/util/AutoEqParser.kt
@@ -15,8 +15,8 @@ data class PeqBand(
 object AutoEqParser {
     private const val TAG = "AutoEqParser"
 
-    // Parses a standard AutoEQ txt file.
-    // Handles GraphicEQ and ParametricEQ formats.
+    // 解析标准的 AutoEQ txt 文件。
+    // 支持 GraphicEQ 和 ParametricEQ 格式。
     fun parse(context: Context, uri: Uri): List<PeqBand>? {
         try {
             val bands = mutableListOf<PeqBand>()
@@ -52,12 +52,11 @@ object AutoEqParser {
                 try {
                     val freq = parts[0].toFloat()
                     val gain = parts[1].toFloat()
-                    // GraphicEQ essentially has fixed Q depending on band spacing,
-                    // but we'll default to 1.41 (sqrt(2)) which is a common 1-octave Q,
-                    // or maybe 1.0. Let's use 1.41.
+                    // GraphicEQ 的 Q 值实际上取决于频段间距，
+                    // 这里默认使用 1.41 (sqrt(2))，这是一个常见的1倍频程 Q 值。
                     bands.add(PeqBand(freq, gain, 1.41f))
                 } catch (e: Exception) {
-                    // ignore format errors for single bands
+                    // 忽略单个频段的格式错误
                 }
             }
         }
@@ -65,7 +64,7 @@ object AutoEqParser {
     }
 
     private fun parseParametricEqLine(line: String): PeqBand? {
-        // Example: Filter 1: ON PK Fc 32 Hz Gain 1.5 dB Q 0.8
+        // 示例：Filter 1: ON PK Fc 32 Hz Gain 1.5 dB Q 0.8
         try {
             val parts = line.split("\\s+".toRegex())
             val fcIndex = parts.indexOf("Fc")
@@ -82,7 +81,7 @@ object AutoEqParser {
                 return PeqBand(freq, gain, q)
             }
         } catch (e: Exception) {
-            // ignore malformed lines
+            // 忽略格式错误的行
         }
         return null
     }

--- a/app/src/main/java/cp/player/util/DspPreferences.kt
+++ b/app/src/main/java/cp/player/util/DspPreferences.kt
@@ -7,12 +7,18 @@ import com.google.gson.reflect.TypeToken
 
 object DspPreferences {
     private const val PREFS_NAME = "cp_player_dsp_prefs"
+    private val gson = Gson()
     private const val KEY_EQ_ENABLED = "flick_eq_enabled"
     private const val KEY_PEQ_BANDS = "flick_peq_bands"
     private const val KEY_FX_ENABLED = "flick_fx_enabled"
     private const val KEY_FX_SIZE = "flick_fx_size"
     private const val KEY_FX_MIX = "flick_fx_mix"
     private const val KEY_FX_WIDTH = "flick_fx_width"
+
+    private const val KEY_EXO_EQ_ENABLED = "exo_eq_enabled"
+    private const val KEY_EXO_VIRTUALIZER_ENABLED = "exo_virtualizer_enabled"
+    private const val KEY_EXO_VIRTUALIZER_STRENGTH = "exo_virtualizer_strength"
+    private const val KEY_EXO_EQ_GAINS = "exo_eq_gains"
 
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -37,14 +43,38 @@ object DspPreferences {
         val json = getPrefs(context).getString(KEY_PEQ_BANDS, null) ?: return emptyList()
         val type = object : TypeToken<List<PeqBand>>() {}.type
         return try {
-            Gson().fromJson(json, type) ?: emptyList()
+            gson.fromJson(json, type) ?: emptyList()
         } catch (e: Exception) {
             emptyList()
         }
     }
 
     fun setPeqBands(context: Context, bands: List<PeqBand>) {
-        val json = Gson().toJson(bands)
+        val json = gson.toJson(bands)
         getPrefs(context).edit().putString(KEY_PEQ_BANDS, json).apply()
+    }
+
+    fun getExoEqEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_EXO_EQ_ENABLED, false)
+    fun setExoEqEnabled(context: Context, enabled: Boolean) = getPrefs(context).edit().putBoolean(KEY_EXO_EQ_ENABLED, enabled).apply()
+
+    fun getExoVirtualizerEnabled(context: Context): Boolean = getPrefs(context).getBoolean(KEY_EXO_VIRTUALIZER_ENABLED, false)
+    fun setExoVirtualizerEnabled(context: Context, enabled: Boolean) = getPrefs(context).edit().putBoolean(KEY_EXO_VIRTUALIZER_ENABLED, enabled).apply()
+
+    fun getExoVirtualizerStrength(context: Context): Short = getPrefs(context).getInt(KEY_EXO_VIRTUALIZER_STRENGTH, 0).toShort()
+    fun setExoVirtualizerStrength(context: Context, strength: Short) = getPrefs(context).edit().putInt(KEY_EXO_VIRTUALIZER_STRENGTH, strength.toInt()).apply()
+
+    fun getExoEqGains(context: Context): Map<Short, Short> {
+        val json = getPrefs(context).getString(KEY_EXO_EQ_GAINS, null) ?: return emptyMap()
+        val type = object : TypeToken<Map<Short, Short>>() {}.type
+        return try {
+            gson.fromJson(json, type) ?: emptyMap()
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+
+    fun setExoEqGains(context: Context, gains: Map<Short, Short>) {
+        val json = gson.toJson(gains)
+        getPrefs(context).edit().putString(KEY_EXO_EQ_GAINS, json).apply()
     }
 }

--- a/app/src/main/rust/src/audio/equalizer.rs
+++ b/app/src/main/rust/src/audio/equalizer.rs
@@ -1,10 +1,10 @@
-//! Parametric EQ: Configurable peaking biquad bands at variable frequencies, gains, and Q values.
-//! Single responsibility: apply band gains to interleaved f32 samples.
+//! 参数均衡器（Parametric EQ）：具有可变频率、增益和 Q 值的可配置峰值双二阶滤波频段。
+//! 单一职责：将频段增益应用于交错的 f32 样本。
 
 use std::f32::consts::PI;
 use std::sync::atomic::{AtomicU8, Ordering};
 
-pub const MAX_BANDS: usize = 30; // Support up to 30 custom bands
+pub const MAX_BANDS: usize = 30; // 最多支持 30 个自定义频段
 const COEFFS_PER_BAND: usize = 5;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -24,7 +24,7 @@ impl Default for PeqBand {
     }
 }
 
-/// Biquad coeffs per band: b0, b1, b2, a1, a2 (a0 normalized to 1).
+/// 每个频段的双二阶系数：b0, b1, b2, a1, a2 (a0 归一化为 1)。
 #[derive(Clone, Copy)]
 pub struct EqParams {
     pub enabled: bool,
@@ -41,7 +41,7 @@ impl EqParams {
         }
     }
 
-    /// Build from dynamic PEQ bands and sample rate.
+    /// 从动态的 PEQ 频段和采样率构建。
     pub fn from_peq_bands(bands: &[PeqBand], sample_rate: u32) -> Self {
         let fs = sample_rate as f32;
         let mut coeffs = [[1.0, 0.0, 0.0, 0.0, 0.0]; MAX_BANDS];
@@ -49,7 +49,17 @@ impl EqParams {
 
         for i in 0..num_bands {
             let band = &bands[i];
-            let (b0, b1, b2, a1, a2) = peaking_coeffs(band.freq_hz, band.gain_db, band.q, fs);
+
+            // 验证并限制参数以防止生成 inf/NaN 系数
+            let q = if band.q <= 0.0 { 0.1 } else { band.q };
+            let mut freq_hz = band.freq_hz;
+            if freq_hz <= 0.0 {
+                freq_hz = 1.0;
+            } else if freq_hz >= fs / 2.0 {
+                freq_hz = fs / 2.0 - 1.0;
+            }
+
+            let (b0, b1, b2, a1, a2) = peaking_coeffs(freq_hz, band.gain_db, q, fs);
             coeffs[i] = [b0, b1, b2, a1, a2];
         }
 
@@ -61,7 +71,7 @@ impl EqParams {
     }
 }
 
-/// Peaking EQ: A = 10^(dBgain/40), w0 = 2*pi*f0/Fs, alpha = sin(w0)/(2*Q).
+/// 峰值均衡器：A = 10^(dBgain/40), w0 = 2*pi*f0/Fs, alpha = sin(w0)/(2*Q)。
 fn peaking_coeffs(f0: f32, gain_db: f32, q: f32, fs: f32) -> (f32, f32, f32, f32, f32) {
     let a = 10.0f32.powf(gain_db / 40.0);
     let w0 = 2.0 * PI * f0 / fs;
@@ -77,16 +87,16 @@ fn peaking_coeffs(f0: f32, gain_db: f32, q: f32, fs: f32) -> (f32, f32, f32, f32
     (b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0)
 }
 
-/// Per-channel, per-band biquad state: x1, x2, y1, y2.
+/// 单通道、单频段的双二阶状态：x1, x2, y1, y2。
 type BandState = [f32; 4];
 type ChannelState = [BandState; MAX_BANDS];
 
-/// Double-buffered params for lock-free updates from command thread.
-/// State is per-channel (not double-buffered) for stereo processing.
+/// 双缓冲参数，用于命令线程的无锁更新。
+/// 状态是按通道分配的（非双缓冲），用于立体声处理。
 pub struct Equalizer {
     params: [EqParams; 2],
     index: AtomicU8,
-    /// Per-channel filter state. Indexed by channel (0=left, 1=right).
+    /// 单通道滤波器状态。按通道索引（0=左，1=右）。
     state: [ChannelState; 2],
 }
 
@@ -99,7 +109,7 @@ impl Equalizer {
         }
     }
 
-    /// Called from command thread. sample_rate must match engine.
+    /// 从命令线程调用。sample_rate 必须匹配引擎。
     pub fn set(&mut self, enabled: bool, bands: &[PeqBand], sample_rate: u32) {
         let next = if enabled {
             EqParams::from_peq_bands(bands, sample_rate)
@@ -110,7 +120,7 @@ impl Equalizer {
         self.params[1 - idx as usize] = next;
         self.index.store(1 - idx, Ordering::Release);
 
-        // Reset state when disabling to avoid artifacts when re-enabling
+        // 禁用时重置状态，以避免重新启用时出现伪影
         if !enabled {
             for ch_state in &mut self.state {
                 for band_state in ch_state.iter_mut() {
@@ -125,13 +135,13 @@ impl Equalizer {
         self.params[self.index.load(Ordering::Acquire) as usize]
     }
 
-    /// Process interleaved buffer in place. channels = 2.
+    /// 就地处理交错缓冲区。channels = 2。
     pub fn process(&mut self, buf: &mut [f32], channels: usize) {
         let p = self.current_params();
         if !p.enabled || p.num_bands == 0 {
             return;
         }
-        // Clamp channels to available state buffers (typically 2 for stereo)
+        // 将通道数限制在可用的状态缓冲区内（通常立体声为 2）
         let max_channels = self.state.len().min(channels);
         let frames = buf.len() / channels;
         let active_coeffs = &p.coeffs[..p.num_bands];
@@ -153,7 +163,7 @@ fn process_sample_chain(
     state: &mut ChannelState,
 ) -> f32 {
     let mut x = x0;
-    // Only process up to coeffs.len() bands
+    // 仅处理最多 coeffs.len() 个频段
     for (i, b) in coeffs.iter().enumerate() {
         let s = &mut state[i];
         let (b0, b1, b2, a1, a2) = (b[0], b[1], b[2], b[3], b[4]);


### PR DESCRIPTION
Addresses bugs identified in the DSP and Equalizer implementation. Reuses Gson instance to avoid object allocation loop. Adds missing 'dsp' screen navigation. Adapts ExoAudioFxManager to properly manage multiple audio sessions simultaneously. Clamps bounds for Rust PEQ input parameters. Persists EQ and Virtualizer preferences correctly across restarts.

---
*PR created automatically by Jules for task [4365190578707421693](https://jules.google.com/task/4365190578707421693) started by @Aurora-Nasa-1*