### PR TITLE
Fix UnspecifiedRegisterReceiverFlag lint error in UsbAudioManager

### DIFF
--- a/app/src/main/java/cp/player/engine/UsbAudioManager.kt
+++ b/app/src/main/java/cp/player/engine/UsbAudioManager.kt
@@ -11,6 +11,7 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import android.os.Build
 import android.util.Log
+import androidx.core.content.ContextCompat
 import cp.player.util.UserPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,11 +89,13 @@ class UsbAudioManager(private val context: Context) : SharedPreferences.OnShared
             addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED)
             addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(usbReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            context.registerReceiver(usbReceiver, filter)
-        }
+
+        ContextCompat.registerReceiver(
+            context,
+            usbReceiver,
+            filter,
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
 
         UserPreferences.getPrefs(context).registerOnSharedPreferenceChangeListener(this)
 


### PR DESCRIPTION
Refactored `UsbAudioManager.kt` to use `ContextCompat.registerReceiver` instead of manually checking for API versions. This resolves the `UnspecifiedRegisterReceiverFlag` lint error for `RECEIVER_NOT_EXPORTED` flags, ensuring compatibility and better code practices across older API versions.

---
*PR created automatically by Jules for task [18049114801216491940](https://jules.google.com/task/18049114801216491940) started by @Aurora-Nasa-1*