### PR TITLE
Fix USB exclusive mode not automatically working on hot-plug

### DIFF
--- a/app/src/main/java/cp/player/engine/UsbAudioManager.kt
+++ b/app/src/main/java/cp/player/engine/UsbAudioManager.kt
@@ -122,7 +122,7 @@ class UsbAudioManager(private val context: Context) : SharedPreferences.OnShared
 
     private fun scanForUsbAudioDevices() {
         if (!UserPreferences.getUsbExclusive(context)) return
-        // ONLY detach and register if the active engine is Flick Engine (1)
+
         if (UserPreferences.getAudioEngine(context) != 1) return
 
         val deviceList = usbManager.deviceList
@@ -145,6 +145,7 @@ class UsbAudioManager(private val context: Context) : SharedPreferences.OnShared
 
     private fun checkAndRequestPermission(device: UsbDevice) {
         if (!UserPreferences.getUsbExclusive(context)) return
+        if (UserPreferences.getAudioEngine(context) != 1) return
         if (!isUsbAudioDevice(device)) return
 
         if (usbManager.hasPermission(device)) {

--- a/app/src/main/java/cp/player/engine/UsbAudioManager.kt
+++ b/app/src/main/java/cp/player/engine/UsbAudioManager.kt
@@ -50,7 +50,7 @@ class UsbAudioManager(private val context: Context) : SharedPreferences.OnShared
                         }
 
                         if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
-                            device?.let { registerDevice(it) }
+                            device?.let { checkAndRequestPermission(it) }
                         } else {
                             Log.d(TAG, "permission denied for device $device")
                         }
@@ -167,6 +167,7 @@ class UsbAudioManager(private val context: Context) : SharedPreferences.OnShared
 
     private fun registerDevice(device: UsbDevice) {
         if (registeredDevice == device) return
+        if (!UserPreferences.getUsbExclusive(context) || UserPreferences.getAudioEngine(context) != 1) return
 
         scope.launch(Dispatchers.IO) {
             try {

--- a/app/src/main/java/cp/player/service/MusicService.kt
+++ b/app/src/main/java/cp/player/service/MusicService.kt
@@ -266,6 +266,7 @@ class MusicService : MediaSessionService() {
         DebugLog.i("MusicService: Service onCreate")
 
         usbAudioManager = UsbAudioManager(this)
+        usbAudioManager?.start()
         audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         registerReceiver(noisyReceiver, IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY))
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -551,7 +552,7 @@ class MusicService : MediaSessionService() {
 
             // Update USB audio manager
             if (engineType == 1) {
-                if (usbAudioManager == null) usbAudioManager = cp.player.engine.UsbAudioManager(this)
+                if (usbAudioManager == null) { usbAudioManager = cp.player.engine.UsbAudioManager(this); usbAudioManager?.start() }
             } else {
                 usbAudioManager?.stop()
                 usbAudioManager = null


### PR DESCRIPTION
- Started `usbAudioManager` when created in `MusicService.kt`.
- Added missing `getAudioEngine` checks in `UsbAudioManager.kt` to ensure we don't attempt to request permission or steal the kernel driver when the active engine does not support it.

---
*PR created automatically by Jules for task [13875034303051893721](https://jules.google.com/task/13875034303051893721) started by @Aurora-Nasa-1*