### PR TITLE
fix: remove Sentry test exception in MainActivity

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -66,15 +66,6 @@ class MainActivity : ComponentActivity() {
         // 处理通过 Manifest intent-filter 启动的 USB 设备附加事件
         handleUsbDeviceIntent(intent)
 
-    // waiting for view to draw to better represent a captured error with a screenshot
-    findViewById<android.view.View>(android.R.id.content).viewTreeObserver.addOnGlobalLayoutListener {
-      try {
-        throw Exception("This app uses Sentry! :)")
-      } catch (e: Exception) {
-        Sentry.captureException(e)
-      }
-    }
-
         enableEdgeToEdge()
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)


### PR DESCRIPTION
Removed the block of code inside `MainActivity.onCreate` that was throwing and capturing a test exception (`"This app uses Sentry! :)"`) on every view tree observer global layout update. This resolves the reported Sentry issue `[ANDROID-G]`.

---
*PR created automatically by Jules for task [15545167777744372483](https://jules.google.com/task/15545167777744372483) started by @Aurora-Nasa-1*