### PR TITLE
Fix: Remove Sentry test exception in MainActivity

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -66,15 +66,6 @@ class MainActivity : ComponentActivity() {
         // 处理通过 Manifest intent-filter 启动的 USB 设备附加事件
         handleUsbDeviceIntent(intent)
 
-    // waiting for view to draw to better represent a captured error with a screenshot
-    findViewById<android.view.View>(android.R.id.content).viewTreeObserver.addOnGlobalLayoutListener {
-      try {
-        throw Exception("This app uses Sentry! :)")
-      } catch (e: Exception) {
-        Sentry.captureException(e)
-      }
-    }
-
         enableEdgeToEdge()
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)


### PR DESCRIPTION
Removes a block of code in MainActivity.kt that threw a dummy exception used for testing Sentry integration, resolving the Sentry issue [ANDROID-G].

---
*PR created automatically by Jules for task [3452132042524952213](https://jules.google.com/task/3452132042524952213) started by @Aurora-Nasa-1*