### PR TITLE
Fix Library screen layout padding clipping background at the bottom

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
@@ -45,7 +45,7 @@ fun CloudMusicContent(
                     start = 0.dp,
                     end = 0.dp,
                     top = 16.dp,
-                    bottom = bottomContentPadding.calculateBottomPadding() + 16.dp
+                    bottom = bottomContentPadding.calculateBottomPadding() + 80.dp
                 ),
                 verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {

--- a/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
@@ -298,7 +298,7 @@ private fun DownloadsMainContent(
                 start = 0.dp,
                 end = 0.dp,
                 top = 16.dp,
-                bottom = bottomContentPadding.calculateBottomPadding() + 16.dp
+                bottom = bottomContentPadding.calculateBottomPadding() + 80.dp
             ),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {

--- a/app/src/main/java/cp/player/ui/screen/LibraryScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/LibraryScreen.kt
@@ -94,15 +94,14 @@ fun LibraryScreen(
     }
 
     Scaffold(
-        containerColor = MaterialTheme.colorScheme.surface,
-        modifier = Modifier.padding(bottom = bottomContentPadding.calculateBottomPadding())
+        containerColor = MaterialTheme.colorScheme.surface
     ) { innerPadding ->
         Box(modifier = Modifier.fillMaxSize()) {
 
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
+                    .padding(top = innerPadding.calculateTopPadding(), start = innerPadding.calculateStartPadding(androidx.compose.ui.platform.LocalLayoutDirection.current), end = innerPadding.calculateEndPadding(androidx.compose.ui.platform.LocalLayoutDirection.current))
             ) {
                 // 1. Top Filters with Animated Indicator
                 LibraryTopFilters(
@@ -135,7 +134,7 @@ fun LibraryScreen(
                             0 -> { // Playlists
                                 LazyColumn(
                                     modifier = Modifier.fillMaxSize(),
-                                    contentPadding = PaddingValues(top = 16.dp, bottom = 100.dp)
+                                    contentPadding = PaddingValues(top = 16.dp, bottom = bottomContentPadding.calculateBottomPadding() + 80.dp)
                                 ) {
                                     item {
                                         PlaylistsControlBar(
@@ -193,7 +192,7 @@ fun LibraryScreen(
                                         userViewModel.addSongsToPlaylist(playlistId, songIds, cp.player.util.UserPreferences.getCookie(context))
                                     },
                                     allPlaylists = userPlaylists,
-                                    bottomContentPadding = PaddingValues(bottom = 100.dp)
+                                    bottomContentPadding = bottomContentPadding
                                 )
                             }
                             2 -> { // Cloud
@@ -209,14 +208,14 @@ fun LibraryScreen(
                                     onDownloadClick = downloadViewModel?.let { vm -> { s -> vm.downloadSong(s) } },
                                     downloadedSongIds = downloadedSongIds,
                                     playbackViewModel = playbackViewModel,
-                                    bottomContentPadding = PaddingValues(bottom = 100.dp)
+                                    bottomContentPadding = bottomContentPadding
                                 )
                             }
                             3 -> { // Live Sort
                                 cp.player.ui.screen.LiveSortContent(
                                     liveSortViewModel = liveSortViewModel,
                                     playbackViewModel = playbackViewModel,
-                                    bottomContentPadding = PaddingValues(bottom = 100.dp)
+                                    bottomContentPadding = bottomContentPadding
                                 )
                             }
                         }

--- a/app/src/main/java/cp/player/ui/screen/LiveSortScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/LiveSortScreen.kt
@@ -71,7 +71,7 @@ fun LiveSortContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = bottomContentPadding.calculateBottomPadding())
+            .padding(bottom = bottomContentPadding.calculateBottomPadding() + 80.dp)
     ) {
         when (val state = sortState) {
             is LiveSortState.Idle -> IdleState(


### PR DESCRIPTION
Fix Library screen layout padding clipping background at the bottom

Removed hardcoded `Modifier.padding(bottom)` from the Scaffold in `LibraryScreen.kt` to allow the background to extend to the bottom edge of the screen correctly. Refactored list content scrolling paddings in `LibraryScreen` by passing dynamic `bottomContentPadding` to internal screens, accounting for an 80.dp offset from the miniplayer overlaid bottom padding so items are not occluded. Updated all tab pages (Playlists, Downloads, Cloud, LiveSort) appropriately to prevent any empty space or content truncation near the navigation controls.

---
*PR created automatically by Jules for task [1314993189188202129](https://jules.google.com/task/1314993189188202129) started by @Aurora-Nasa-1*