### PR TITLE
Optimize FloatArray creation for RustEngine setEqualizer calls

### DIFF
--- a/app/src/main/java/cp/player/engine/FlickPlayer.kt
+++ b/app/src/main/java/cp/player/engine/FlickPlayer.kt
@@ -167,8 +167,20 @@ class FlickPlayer(private val context: Context) : SimpleBasePlayer(Looper.getMai
             val bands = DspPreferences.getPeqBands(ctx)
             Log.i(TAG, "initDspFromPrefs: eqEnabled=$eqEnabled, bands=${bands.size}")
             if (eqEnabled) {
-                val result = if (bands.isEmpty()) RustEngine.setEqualizer(true, floatArrayOf(), floatArrayOf(), floatArrayOf())
-                else RustEngine.setEqualizer(true, bands.map { it.freq }.toFloatArray(), bands.map { it.gain }.toFloatArray(), bands.map { it.q }.toFloatArray())
+                val result = if (bands.isEmpty()) {
+                    RustEngine.setEqualizer(true, floatArrayOf(), floatArrayOf(), floatArrayOf())
+                } else {
+                    val freqs = FloatArray(bands.size)
+                    val gains = FloatArray(bands.size)
+                    val qs = FloatArray(bands.size)
+                    for (i in bands.indices) {
+                        val band = bands[i]
+                        freqs[i] = band.freq
+                        gains[i] = band.gain
+                        qs[i] = band.q
+                    }
+                    RustEngine.setEqualizer(true, freqs, gains, qs)
+                }
                 Log.i(TAG, "initDspFromPrefs: setEqualizer result=$result")
             }
             val fxEnabled = DspPreferences.getFxEnabled(ctx)

--- a/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
@@ -92,8 +92,20 @@ fun DspSettingsScreen(onNavigateBack: () -> Unit) {
     LaunchedEffect(Unit) {
         // EQ
         if (flickEqEnabled) {
-            if (peqBands.isEmpty()) RustEngine.setEqualizer(true, floatArrayOf(), floatArrayOf(), floatArrayOf())
-            else RustEngine.setEqualizer(true, peqBands.map { it.freq }.toFloatArray(), peqBands.map { it.gain }.toFloatArray(), peqBands.map { it.q }.toFloatArray())
+            if (peqBands.isEmpty()) {
+                RustEngine.setEqualizer(true, floatArrayOf(), floatArrayOf(), floatArrayOf())
+            } else {
+                val freqs = FloatArray(peqBands.size)
+                val gains = FloatArray(peqBands.size)
+                val qs = FloatArray(peqBands.size)
+                for (i in peqBands.indices) {
+                    val band = peqBands[i]
+                    freqs[i] = band.freq
+                    gains[i] = band.gain
+                    qs[i] = band.q
+                }
+                RustEngine.setEqualizer(true, freqs, gains, qs)
+            }
         }
         // FX
         if (fxEnabled) {
@@ -108,8 +120,20 @@ fun DspSettingsScreen(onNavigateBack: () -> Unit) {
 
     fun applyEq() {
         DspPreferences.setEqEnabled(context, flickEqEnabled); DspPreferences.setPeqBands(context, peqBands.toList())
-        if (peqBands.isEmpty()) { RustEngine.setEqualizer(flickEqEnabled, floatArrayOf(), floatArrayOf(), floatArrayOf()); return }
-        RustEngine.setEqualizer(flickEqEnabled, peqBands.map { it.freq }.toFloatArray(), peqBands.map { it.gain }.toFloatArray(), peqBands.map { it.q }.toFloatArray())
+        if (peqBands.isEmpty()) {
+            RustEngine.setEqualizer(flickEqEnabled, floatArrayOf(), floatArrayOf(), floatArrayOf())
+            return
+        }
+        val freqs = FloatArray(peqBands.size)
+        val gains = FloatArray(peqBands.size)
+        val qs = FloatArray(peqBands.size)
+        for (i in peqBands.indices) {
+            val band = peqBands[i]
+            freqs[i] = band.freq
+            gains[i] = band.gain
+            qs[i] = band.q
+        }
+        RustEngine.setEqualizer(flickEqEnabled, freqs, gains, qs)
     }
     fun applyFx() {
         DspPreferences.setFxEnabled(context, fxEnabled); DspPreferences.setFxSize(context, fxSize); DspPreferences.setFxMix(context, fxMix); DspPreferences.setFxWidth(context, fxWidth)


### PR DESCRIPTION
This commit refactors the parameter passing for `RustEngine.setEqualizer` in both `FlickPlayer.kt` and `DspSettingsScreen.kt`. Previously, the code extracted the frequency, gain, and Q values using chained `.map { }.toFloatArray()` calls. This resulted in three separate passes over the underlying list and the unnecessary creation of intermediate `ArrayList` objects for each map operation.

The updated logic now pre-allocates three `FloatArray`s of the correct size and populates them using a single indexed `for` loop. This change reduces memory pressure and execution time by avoiding intermediate collections entirely.

---
*PR created automatically by Jules for task [3314071773173141096](https://jules.google.com/task/3314071773173141096) started by @Aurora-Nasa-1*