### PR TITLE
Fix music cover color extraction for dynamic theming

### DIFF
--- a/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
+++ b/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
@@ -11,6 +11,7 @@ import coil3.toBitmap
 import cp.player.manager.DownloadRegistry
 import cp.player.model.Song
 import cp.player.util.DebugLog
+import cp.player.util.resized
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -20,16 +21,17 @@ class MediaMetadataUseCase(private val application: Application) {
     suspend fun extractColorFromUrl(url: String?): Int? = withContext(Dispatchers.IO) {
         if (url.isNullOrEmpty()) return@withContext null
         try {
+            val resizedUrl = url.resized(300)
             val loader = SingletonImageLoader.get(application)
             val request = ImageRequest.Builder(application)
-                .data(url)
+                .data(resizedUrl)
                 .allowHardware(false)
                 .build()
             val result = loader.execute(request)
             if (result is SuccessResult) {
                 val bitmap = result.image.toBitmap()
                 val palette = Palette.from(bitmap).generate()
-                val color = palette.getVibrantColor(palette.getMutedColor(0))
+                val color = palette.getDominantColor(palette.getVibrantColor(palette.getMutedColor(0)))
                 if (color != 0) return@withContext color
             }
         } catch (e: Exception) {


### PR DESCRIPTION
The issue stated that the color extraction for the music cover was using a low-resolution image and resulted in incorrect colors that didn't align with Monet styles.

To address this, the URL is now appended with resizing parameters via `url.resized(300)` to ensure a high-enough resolution image is retrieved for accurate color extraction. Additionally, the color extraction logic from the `Palette` was updated to prioritize `getDominantColor` instead of just `getVibrantColor`, which provides a much better base color seed for the Material 3 tonal color scheme generation.

---
*PR created automatically by Jules for task [4751807607826772227](https://jules.google.com/task/4751807607826772227) started by @Aurora-Nasa-1*