### PR TITLE
Fix ANR caused by blocking MediaMetadataRetriever calls

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -477,6 +477,7 @@ fun AppMainContent(
                                 userViewModel.fetchCloudSongs()
                             }
                             val navContext = LocalContext.current
+                            val libraryCoroutineScope = rememberCoroutineScope()
                             LibraryScreen(
                                 userPlaylists = userViewModel.userPlaylists,
                                 onPlaylistClick = { p ->
@@ -486,30 +487,34 @@ fun AppMainContent(
 
                                 // Downloads Data
                                 onPlayLocalSong = { s, u ->
-                                    val playlist = if (s.id.startsWith("local_")) {
-                                        downloadViewModel.localSongs.value.map {
-                                            cp.player.model.Song(
-                                                id = it.songId,
-                                                name = it.songName,
-                                                artist = it.artist,
-                                                album = it.album,
-                                                albumArtUrl = cp.player.manager.LocalMusicManager.getCoverArt(
-                                                    navContext, it.songId, it.filePath
+                                    libraryCoroutineScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                                        val playlist = if (s.id.startsWith("local_")) {
+                                            downloadViewModel.localSongs.value.map {
+                                                cp.player.model.Song(
+                                                    id = it.songId,
+                                                    name = it.songName,
+                                                    artist = it.artist,
+                                                    album = it.album,
+                                                    albumArtUrl = cp.player.manager.LocalMusicManager.getCoverArt(
+                                                        navContext, it.songId, it.filePath
+                                                    )
                                                 )
-                                            )
+                                            }
+                                        } else {
+                                            downloadViewModel.downloadedSongs.value.map { metadata ->
+                                                val coverUrl = metadata.localCoverPath
+                                                    ?: cp.player.util.CoverArtExtractor.getOrExtract(
+                                                        navContext, metadata.song.id, metadata.filePath
+                                                    )
+                                                    ?: metadata.song.albumArtUrl
+                                                metadata.song.copy(albumArtUrl = coverUrl)
+                                            }
                                         }
-                                    } else {
-                                        downloadViewModel.downloadedSongs.value.map { metadata ->
-                                            val coverUrl = metadata.localCoverPath
-                                                ?: cp.player.util.CoverArtExtractor.getOrExtract(
-                                                    navContext, metadata.song.id, metadata.filePath
-                                                )
-                                                ?: metadata.song.albumArtUrl
-                                            metadata.song.copy(albumArtUrl = coverUrl)
+                                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                                            playbackViewModel.playSong(s, playlist)
+                                            if (!settingsViewModel.playImmediately) onSetPlayerExpanded(true)
                                         }
                                     }
-                                    playbackViewModel.playSong(s, playlist)
-                                    if (!settingsViewModel.playImmediately) onSetPlayerExpanded(true)
                                 },
                                 downloadedSongs = downloadViewModel.downloadedSongs.collectAsState().value,
                                 localSongs = downloadViewModel.localSongs.collectAsState().value,

--- a/app/src/main/java/cp/player/engine/FlickPlayer.kt
+++ b/app/src/main/java/cp/player/engine/FlickPlayer.kt
@@ -601,9 +601,24 @@ class FlickPlayer(private val context: Context) : SimpleBasePlayer(Looper.getMai
         if (extraDuration > 0) return extraDuration
         val path = item.localConfiguration?.uri?.toString() ?: return 0L
         if (!path.startsWith("cp://") && !path.startsWith("http://") && !path.startsWith("https://")) {
-            return durationCache.getOrPut(path) {
-                extractDuration(Uri.parse(path), false)
+            val cached = durationCache[path]
+            if (cached != null) return cached
+
+            // 异步提取时长，避免阻塞主线程（可能引发 ANR）
+            scope.launch(Dispatchers.IO) {
+                val duration = extractDuration(Uri.parse(path), false)
+                if (duration > 0) {
+                    durationCache[path] = duration
+                    // 通知重新获取并更新状态
+                    withContext(Dispatchers.Main) {
+                        if (currentPlayingPath == path || currentPlayingPath == getRealPathFromUri(path)) {
+                            durationMs = duration
+                            invalidateState()
+                        }
+                    }
+                }
             }
+            return 0L
         }
         return 0L
     }


### PR DESCRIPTION
Resolves an ApplicationNotResponding (ANR) crash reported by Sentry. The issue was triggered by synchronously executing blocking disk I/O operations from `MediaMetadataRetriever.setDataSource` on the main UI thread during metadata extraction (cover art and duration). The extraction processes have been explicitly offloaded to background threads (`Dispatchers.IO`).

---
*PR created automatically by Jules for task [16693892054905846714](https://jules.google.com/task/16693892054905846714) started by @Aurora-Nasa-1*