### PR TITLE
feat: Add dynamic custom settings for backend providers

### DIFF
--- a/PROVIDER_DEV_GUIDE.md
+++ b/PROVIDER_DEV_GUIDE.md
@@ -455,6 +455,13 @@ nativeCallApi(mappedMethod, paramsJson)
 | `msg/private/mark/read` | 标记已读 | `uid`, `cookie` |
 | `send/text` | 发送消息 | `user_ids`, `msg`, `cookie` |
 
+### 7.8 模块设置（自定义界面）
+
+| API 方法名 | 说明 | 参数 |
+|-----------|------|------|
+| `settings/schema` | 获取提供商设置的 UI Schema | 无 |
+| `settings/save` | 保存并同步用户设置到提供商 | `settings` (包含键值对的 JSON 字符串) |
+
 ---
 
 ## 8. 每个 API 的请求与响应格式
@@ -843,6 +850,66 @@ nativeCallApi(mappedMethod, paramsJson)
 #### `logout` — 登出
 
 **请求：** `{}`
+
+**响应：**
+```json
+{ "code": 200 }
+```
+
+#### `settings/schema` — 获取提供商设置的 UI Schema
+
+**请求：** `{}`
+
+**响应：**
+```json
+{
+    "code": 200,
+    "data": [
+        {
+            "key": "server_url",
+            "name": "服务器地址",
+            "type": "input",
+            "description": "自定义后端服务器地址",
+            "defaultValue": "https://api.example.com"
+        },
+        {
+            "key": "enable_hifi",
+            "name": "开启 Hi-Fi",
+            "type": "switch",
+            "defaultValue": false
+        },
+        {
+            "key": "quality_limit",
+            "name": "最高音质限制",
+            "type": "select",
+            "defaultValue": "lossless",
+            "options": [
+                { "label": "标准", "value": "standard" },
+                { "label": "无损", "value": "lossless" },
+                { "label": "Hi-Res", "value": "hires" }
+            ]
+        }
+    ]
+}
+```
+
+> **字段说明：**
+> - `key`: 设置项的唯一标识。
+> - `name`: 显示在界面的设置名称。
+> - `type`: 支持 `input` (文本框), `switch` (开关), `select` (下拉单选)。
+> - `description`: (可选) 设置项的描述。
+> - `defaultValue`: (可选) 默认值。
+> - `options`: 仅 `select` 类型需要，提供可选的下拉选项列表。
+
+#### `settings/save` — 保存并同步用户设置到提供商
+
+**请求：**
+```json
+{
+    "settings": "{\"server_url\":\"https://myapi.com\",\"enable_hifi\":true,\"quality_limit\":\"hires\"}"
+}
+```
+> `settings` 是一个包含了用户修改后的设置键值对的 JSON 字符串。
 
 **响应：**
 ```json

--- a/app/src/main/java/cp/player/manager/ProviderSettingsManager.kt
+++ b/app/src/main/java/cp/player/manager/ProviderSettingsManager.kt
@@ -1,0 +1,75 @@
+package cp.player.manager
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import cp.player.provider.BackendProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Manager for persisting and syncing custom settings for each backend provider.
+ */
+object ProviderSettingsManager {
+    private const val PREFS_NAME = "cp_provider_settings_prefs"
+    private val gson = Gson()
+
+    private fun getPrefs(context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    /**
+     * Gets the saved settings for a specific provider as a Map.
+     */
+    fun getSettings(context: Context, providerId: String): Map<String, Any> {
+        val jsonStr = getPrefs(context).getString(providerId, null)
+        if (jsonStr.isNullOrEmpty()) {
+            return emptyMap()
+        }
+        return try {
+            val type = object : TypeToken<Map<String, Any>>() {}.type
+            gson.fromJson(jsonStr, type) ?: emptyMap()
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+
+    /**
+     * Saves the settings for a specific provider and optionally syncs them to the backend.
+     */
+    suspend fun saveSettings(context: Context, provider: BackendProvider, newSettings: Map<String, Any>) {
+        // Persist locally
+        val jsonStr = gson.toJson(newSettings)
+        getPrefs(context).edit().putString(provider.id, jsonStr).apply()
+
+        // Sync to backend via API
+        syncSettingsToBackend(provider, jsonStr)
+    }
+
+    /**
+     * Syncs the JSON string of settings to the backend via settings/save
+     */
+    suspend fun syncSettingsToBackend(provider: BackendProvider, settingsJson: String): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val params = mapOf("settings" to settingsJson)
+            val response = provider.callApi("settings/save", params)
+            // Just assume it succeeded if it didn't throw an exception,
+            // or we could check the code in response.
+            response.contains("\"code\": 200") || response.contains("\"code\":200")
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Utility function to call on app start or provider switch to ensure backend has the latest settings.
+     */
+    suspend fun syncLocalSettingsOnStart(context: Context, provider: BackendProvider?) {
+        if (provider == null) return
+        val settingsMap = getSettings(context, provider.id)
+        if (settingsMap.isNotEmpty()) {
+            syncSettingsToBackend(provider, gson.toJson(settingsMap))
+        }
+    }
+}

--- a/app/src/main/java/cp/player/model/ProviderSettingItem.kt
+++ b/app/src/main/java/cp/player/model/ProviderSettingItem.kt
@@ -1,0 +1,20 @@
+package cp.player.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a single setting item defined by a BackendProvider via `settings/schema`.
+ */
+data class ProviderSettingItem(
+    @SerializedName("key") val key: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("type") val type: String, // "switch", "input", "select"
+    @SerializedName("description") val description: String? = null,
+    @SerializedName("defaultValue") val defaultValue: Any? = null,
+    @SerializedName("options") val options: List<ProviderSettingOption>? = null
+)
+
+data class ProviderSettingOption(
+    @SerializedName("label") val label: String,
+    @SerializedName("value") val value: Any
+)

--- a/app/src/main/java/cp/player/provider/ProviderManager.kt
+++ b/app/src/main/java/cp/player/provider/ProviderManager.kt
@@ -3,7 +3,10 @@ package cp.player.provider
 import android.content.Context
 import android.util.Log
 import cp.player.util.DebugLog
+import cp.player.manager.ProviderSettingsManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,6 +89,10 @@ object ProviderManager {
         if (provider != null && context != null) {
             try {
                 provider.startServer(context, port)
+                // 同步设置
+                CoroutineScope(Dispatchers.IO).launch {
+                    ProviderSettingsManager.syncLocalSettingsOnStart(context, provider)
+                }
             } catch (e: Throwable) {
                 // 捕获 Throwable 以处理 JNI 原生崩溃（如 UnsatisfiedLinkError、SIGSEGV 转换的 Error）
                 Log.e(TAG, "Error starting new provider", e)

--- a/app/src/main/java/cp/player/ui/component/ProviderOptionsBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/ProviderOptionsBottomSheet.kt
@@ -46,6 +46,7 @@ fun ProviderOptionsBottomSheet(
     onDeleted: () -> Unit,
     onUpdated: () -> Unit,
     onUpdateZipSelected: (android.net.Uri) -> Unit,
+    onSettingsSelected: () -> Unit = {},
     /** 外部预检查的更新信息（从列表页自动检查传入），null 表示未预检查 */
     preCheckedUpdate: ProviderUpdateChecker.UpdateInfo? = null
 ) {
@@ -233,6 +234,19 @@ fun ProviderOptionsBottomSheet(
                     }
                 )
             }
+
+            // 模块设置
+            PillButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = "模块设置",
+                icon = Icons.Rounded.Settings,
+                bgColor = MaterialTheme.colorScheme.tertiaryContainer,
+                textColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                onClick = {
+                    onSettingsSelected()
+                    onDismissRequest()
+                }
+            )
 
             // 删除按钮
             PillButton(

--- a/app/src/main/java/cp/player/ui/screen/ProviderSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ProviderSettingsScreen.kt
@@ -1,0 +1,215 @@
+package cp.player.ui.screen
+
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.reflect.TypeToken
+import cp.player.manager.ProviderSettingsManager
+import cp.player.model.ProviderSettingItem
+import cp.player.provider.ModuleManager
+import cp.player.provider.ProviderManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProviderSettingsScreen(
+    providerId: String,
+    onNavigateBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val provider = remember { ModuleManager.getAvailableProviders().find { it.id == providerId } }
+
+    var schema by remember { mutableStateOf<List<ProviderSettingItem>?>(null) }
+    var currentValues by remember { mutableStateOf<MutableMap<String, Any>>(mutableMapOf()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isSaving by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(provider) {
+        if (provider == null) {
+            errorMessage = "Provider not found"
+            isLoading = false
+            return@LaunchedEffect
+        }
+
+        try {
+            val response = withContext(Dispatchers.IO) {
+                provider.callApi("settings/schema", emptyMap())
+            }
+
+            val jsonObj = Gson().fromJson(response, JsonObject::class.java)
+            val code = jsonObj.get("code")?.asInt ?: -1
+
+            if (code == -1 || code == 404) {
+                errorMessage = "该提供商不支持自定义设置"
+            } else if (code == 200) {
+                val dataArray = jsonObj.getAsJsonArray("data")
+                val itemType = object : TypeToken<List<ProviderSettingItem>>() {}.type
+                schema = Gson().fromJson(dataArray, itemType)
+
+                // Get locally saved settings
+                val savedSettings = ProviderSettingsManager.getSettings(context, provider.id)
+                currentValues = savedSettings.toMutableMap()
+            } else {
+                errorMessage = jsonObj.get("msg")?.asString ?: "无法获取设置"
+            }
+        } catch (e: Exception) {
+            errorMessage = "错误: ${e.message}"
+        } finally {
+            isLoading = false
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(provider?.name?.plus(" 设置") ?: "设置") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (schema != null) {
+                        TextButton(
+                            onClick = {
+                                if (provider != null) {
+                                    scope.launch {
+                                        isSaving = true
+                                        ProviderSettingsManager.saveSettings(context, provider, currentValues)
+                                        isSaving = false
+                                        Toast.makeText(context, "设置已保存", Toast.LENGTH_SHORT).show()
+                                        onNavigateBack()
+                                    }
+                                }
+                            },
+                            enabled = !isSaving
+                        ) {
+                            if (isSaving) {
+                                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            } else {
+                                Text("保存")
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
+            if (isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else if (errorMessage != null) {
+                Text(
+                    text = errorMessage!!,
+                    modifier = Modifier.align(Alignment.Center).padding(16.dp),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            } else if (schema != null) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(schema!!) { item ->
+                        SettingItemRenderer(
+                            item = item,
+                            currentValue = currentValues[item.key] ?: item.defaultValue,
+                            onValueChanged = { newValue ->
+                                currentValues = currentValues.toMutableMap().apply {
+                                    if (newValue == null) remove(item.key) else put(item.key, newValue)
+                                }
+                            }
+                        )
+                        HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingItemRenderer(
+    item: ProviderSettingItem,
+    currentValue: Any?,
+    onValueChanged: (Any?) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = item.name, style = MaterialTheme.typography.titleMedium)
+        if (!item.description.isNullOrEmpty()) {
+            Text(
+                text = item.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when (item.type) {
+            "switch" -> {
+                val checked = (currentValue as? Boolean) ?: (item.defaultValue as? Boolean) ?: false
+                Switch(
+                    checked = checked,
+                    onCheckedChange = { onValueChanged(it) }
+                )
+            }
+            "input" -> {
+                val text = (currentValue as? String) ?: (item.defaultValue as? String) ?: ""
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { onValueChanged(it) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
+            "select" -> {
+                var expanded by remember { mutableStateOf(false) }
+                val currentOption = item.options?.find { it.value == currentValue }
+                    ?: item.options?.find { it.value == item.defaultValue }
+                val label = currentOption?.label ?: currentValue?.toString() ?: "未选择"
+
+                Box {
+                    OutlinedButton(onClick = { expanded = true }) {
+                        Text(label)
+                    }
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        item.options?.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option.label) },
+                                onClick = {
+                                    onValueChanged(option.value)
+                                    expanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            else -> {
+                Text("不支持的设置类型: ${item.type}", color = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -110,7 +110,16 @@ fun SettingsScreen(
 
     var currentScreen by rememberSaveable { mutableStateOf("main") }
     // 子页面的父页面映射（debug 的子页面返回到 debug，其他返回到 main）
-    val parentScreen = mapOf("health" to "debug", "logViewer" to "debug", "providerTest" to "debug", "about" to "main", "dsp" to "audio")
+    val parentScreen = mapOf(
+        "health" to "debug",
+        "logViewer" to "debug",
+        "providerTest" to "debug",
+        "about" to "main",
+        "dsp" to "audio",
+        "providerSettings" to "provider"
+    )
+
+    var currentProviderSettingsId by rememberSaveable { mutableStateOf("") }
 
     val dirPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree()
@@ -134,6 +143,7 @@ fun SettingsScreen(
         "storage_download" -> R.string.storage_cache
         "debug" -> R.string.debug
         "provider" -> R.string.provider_management
+        "providerSettings" -> R.string.settings // Will be overridden in ProviderSettingsScreen itself
         "about" -> R.string.about
         "sponsor" -> R.string.sponsor
         "health" -> R.string.health_status
@@ -809,10 +819,20 @@ fun SettingsScreen(
                                         updatingProviderId = provider.id
                                         updateLauncher.launch("application/zip")
                                     },
+                                    onSettingsSelected = {
+                                        currentProviderSettingsId = provider.id
+                                        currentScreen = "providerSettings"
+                                    },
                                     preCheckedUpdate = updateResults[provider.id]
                                 )
                             }
                         }
+                    }
+                    "providerSettings" -> {
+                        ProviderSettingsScreen(
+                            providerId = currentProviderSettingsId,
+                            onNavigateBack = { currentScreen = parentScreen["providerSettings"] ?: "provider" }
+                        )
                     }
                     "about" -> {
                         // 关于

--- a/app/src/main/java/cp/player/util/LocalAudioAnalyzer.kt
+++ b/app/src/main/java/cp/player/util/LocalAudioAnalyzer.kt
@@ -40,6 +40,22 @@ object LocalAudioAnalyzer {
         fun toFloatArray(): FloatArray {
             return data.copyOf(size)
         }
+
+        fun get(index: Int): Float {
+            return data[index]
+        }
+
+        fun set(index: Int, element: Float) {
+            data[index] = element
+        }
+
+        fun sum(): Float {
+            var s = 0f
+            for(i in 0 until size) {
+                s += data[i]
+            }
+            return s
+        }
     }
 
     fun analyze(context: Context, uri: Uri): AudioFeatures {


### PR DESCRIPTION
This PR introduces a powerful new feature that enables backend providers to define their own custom settings interface using a JSON schema. CPPlayer parses this schema and dynamically renders native Jetpack Compose UI elements, providing a seamless experience for users to configure module-specific parameters (e.g., custom URLs, feature toggles, or quality preferences).

**Key Changes:**
*   **Dynamic UI Rendering**: `ProviderSettingsScreen` dynamically generates `Switch`, `OutlinedTextField`, and `DropdownMenu` components based on the provider's schema response.
*   **Persistence & Syncing**: Introduced `ProviderSettingsManager` to save user preferences locally per provider, ensuring data is retained across app restarts. Settings are automatically synchronized back to the provider via the `settings/save` API both when modified by the user and during the provider's startup sequence.
*   **Integration**: Added a settings shortcut in the `ProviderOptionsBottomSheet` allowing users to quickly access these configurations. Included fallback logic to inform the user gracefully if a provider does not support custom settings.
*   **Developer Guide**: Updated `PROVIDER_DEV_GUIDE.md` thoroughly documenting the new `settings/schema` and `settings/save` APIs to help third-party developers adopt the feature.

---
*PR created automatically by Jules for task [2650127506269873319](https://jules.google.com/task/2650127506269873319) started by @Aurora-Nasa-1*