### PR TITLE
Fix IllegalArgumentException due to duplicate keys in SearchScreen and LocalAudioAnalyzer compilation issue

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SearchScreen.kt
@@ -238,7 +238,7 @@ fun SearchScreen(
                 } else {
                     when (searchType) {
                         MusicApiMethod.SEARCH_TYPE_SONG -> {
-                            itemsIndexed(searchResults, key = { _, song -> song.id }) { index, song ->
+                            itemsIndexed(searchResults, key = { index, song -> "${song.id}_$index" }) { index, song ->
                                 SongItem(
                                     song = song,
                                     index = index,
@@ -254,7 +254,7 @@ fun SearchScreen(
                             }
                         }
                         MusicApiMethod.SEARCH_TYPE_ALBUM -> {
-                            itemsIndexed(searchPlaylists, key = { _, playlist -> playlist.id }) { index, playlist ->
+                            itemsIndexed(searchPlaylists, key = { index, playlist -> "${playlist.id}_$index" }) { index, playlist ->
                                 PlaylistItem(
                                     playlist = playlist,
                                     index = index,
@@ -266,7 +266,7 @@ fun SearchScreen(
                             }
                         }
                         MusicApiMethod.SEARCH_TYPE_ARTIST -> {
-                            itemsIndexed(searchArtists, key = { _, artist -> artist.id }) { index, artist ->
+                            itemsIndexed(searchArtists, key = { index, artist -> "${artist.id}_$index" }) { index, artist ->
                                 ArtistItem(
                                     artist = artist,
                                     index = index,
@@ -278,7 +278,7 @@ fun SearchScreen(
                             }
                         }
                         MusicApiMethod.SEARCH_TYPE_PLAYLIST -> {
-                            itemsIndexed(searchPlaylists, key = { _, playlist -> playlist.id }) { index, playlist ->
+                            itemsIndexed(searchPlaylists, key = { index, playlist -> "${playlist.id}_$index" }) { index, playlist ->
                                 PlaylistItem(
                                     playlist = playlist,
                                     index = index,

--- a/app/src/main/java/cp/player/util/LocalAudioAnalyzer.kt
+++ b/app/src/main/java/cp/player/util/LocalAudioAnalyzer.kt
@@ -256,11 +256,13 @@ object LocalAudioAnalyzer {
         }
         if (env.size < 32) return 0.0
 
-        val mean = env.sum() / env.size
+        var sumAcc = 0f
+        for (i in 0 until env.size) sumAcc += env.data[i]
+        val mean = sumAcc / env.size
         var varianceAcc = 0f
         for (i in 0 until env.size) {
-            val e = max(0f, env.get(i) - mean)
-            env.set(i, e)
+            val e = max(0f, env.data[i] - mean)
+            env.data[i] = e
             varianceAcc += e * e
         }
         val variance = varianceAcc / max(1, env.size)
@@ -275,7 +277,7 @@ object LocalAudioAnalyzer {
         for (lag in max(1, minLag)..max(minLag + 1, maxLag)) {
             var score = 0f
             for (i in 0 until env.size - lag) {
-                score += env.get(i) * env.get(i + lag)
+                score += env.data[i] * env.data[i + lag]
             }
             if (score > bestScore) {
                 bestScore = score


### PR DESCRIPTION
- Fix `IllegalArgumentException` in `SearchScreen.kt` when backend returns items with duplicate IDs by combining index with ID.
- Fix compilation error for `FloatArrayList` in `LocalAudioAnalyzer.kt`.

---
*PR created automatically by Jules for task [16131930496471981047](https://jules.google.com/task/16131930496471981047) started by @Aurora-Nasa-1*