### PR TITLE
fix: enable lyrics fetching for user-uploaded cloud drive songs

### DIFF
--- a/app/src/main/java/cp/player/lyrics/LyricsManager.kt
+++ b/app/src/main/java/cp/player/lyrics/LyricsManager.kt
@@ -121,15 +121,15 @@ object LyricsManager {
         songTitle: String?,
         songArtist: String?
     ): LyricsState {
-        // 本地歌曲：查询云端绑定 ID，用云端 ID 获取歌词
-        var effectiveId = if (songId.startsWith("local_")) {
+        // 本地歌曲或云盘歌曲：查询云端绑定 ID，用云端 ID 获取歌词
+        var effectiveId = if (songId.startsWith("local_") || songId.startsWith("cloud_")) {
             cp.player.manager.LocalMusicManager.getBinding(songId)?.cloudSongId ?: songId
         } else {
             songId
         }
 
-        // 本地歌曲无绑定时，自动搜索云端匹配歌曲并绑定
-        if (effectiveId.startsWith("local_") && !songTitle.isNullOrBlank()) {
+        // 本地/云盘歌曲无绑定时，自动搜索云端匹配歌曲并绑定
+        if ((effectiveId.startsWith("local_") || effectiveId.startsWith("cloud_")) && !songTitle.isNullOrBlank()) {
             effectiveId = autoSearchAndBind(songId, songTitle, songArtist, context) ?: effectiveId
         }
 
@@ -172,17 +172,17 @@ object LyricsManager {
 
     /**
      * 自动搜索云端匹配歌曲并绑定，返回云端歌曲 ID。
-     * 仅用于本地歌曲无绑定时的自动匹配。
+     * 仅用于本地歌曲/云盘歌曲无绑定时的自动匹配。
      */
     private suspend fun autoSearchAndBind(
-        localSongId: String,
+        sourceSongId: String,
         title: String,
         artist: String?,
         context: Context
     ): String? {
         return try {
             val api = cp.player.api.MusicApiServiceFactory.instance
-            val query = if (!artist.isNullOrBlank()) "$title $artist" else title
+            val query = if (!artist.isNullOrBlank() && artist != "Unknown") "$title $artist" else title
             DebugLog.i("LyricsManager: auto-searching cloud for [$query]")
             val body = withContext(Dispatchers.IO) {
                 api.search(query, 1)
@@ -198,7 +198,7 @@ object LyricsManager {
             val best = candidates?.firstOrNull()
             if (best != null) {
                 DebugLog.i("LyricsManager: auto-bound [$title] → [${best.name}] (cloudId=${best.id})")
-                cp.player.manager.LocalMusicManager.bind(context, localSongId, best)
+                cp.player.manager.LocalMusicManager.bind(context, sourceSongId, best)
                 best.id
             } else {
                 DebugLog.w("LyricsManager: no cloud match for [$title]")

--- a/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cp.player.R
+import androidx.compose.ui.platform.LocalContext
+import cp.player.manager.LocalMusicManager
+
 import cp.player.model.Song
 import cp.player.ui.component.SongItem
 import cp.player.viewmodel.PlaybackViewModel
@@ -27,6 +30,8 @@ fun CloudMusicContent(
     bottomContentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     var selectedSongForOptions by remember { mutableStateOf<Song?>(null) }
+    var showBindSheet by remember { mutableStateOf<Song?>(null) }
+    val context = LocalContext.current
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (isLoading && songs.isEmpty()) {
@@ -86,11 +91,28 @@ fun CloudMusicContent(
                 selectedSongForOptions = null
             },
             onDownloadClick = onDownloadClick?.let { dl -> { dl(song) } },
+            onBindCloudClick = {
+                showBindSheet = song
+                selectedSongForOptions = null
+            },
             isDownloaded = downloadedSongIds.contains(song.id),
             showFavorite = false,
             showShare = false,
             showPlaylist = false,
-            showInfo = false
+            showInfo = false,
+            showBindCloud = true
+        )
+    }
+
+    showBindSheet?.let { song ->
+        cp.player.ui.component.BindCloudSongSheet(
+            songName = song.name,
+            artistName = song.artist,
+            onSongSelected = { cloudSong ->
+                LocalMusicManager.bind(context, song.id, cloudSong)
+                showBindSheet = null
+            },
+            onDismissRequest = { showBindSheet = null }
         )
     }
 }

--- a/app/src/main/java/cp/player/util/JsonUtils.kt
+++ b/app/src/main/java/cp/player/util/JsonUtils.kt
@@ -70,7 +70,7 @@ object JsonUtils {
                 ?: simpleSong?.get("dt")?.asLong ?: 0L
 
             Song(
-                id = songId,
+                id = "cloud_$songId",
                 name = songName,
                 artist = artist,
                 album = album,

--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -490,6 +490,47 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                     else -> emptyList()
                 }
                 cloudSongs = songs
+
+                // Extract simpleSong.id and bind it
+                withContext(Dispatchers.IO) {
+                    val elements = when {
+                        dataElem == null || dataElem.isJsonNull -> emptyList()
+                        dataElem.isJsonArray -> dataElem.asJsonArray.toList()
+                        dataElem.isJsonObject -> {
+                            val innerData = dataElem.asJsonObject.get("data")
+                            if (innerData != null && innerData.isJsonArray) {
+                                innerData.asJsonArray.toList()
+                            } else {
+                                cp.player.util.JsonUtils.findJsonArray(dataElem, "data")?.toList() ?: emptyList()
+                            }
+                        }
+                        else -> emptyList()
+                    }
+
+                    for (element in elements) {
+                        try {
+                            if (!element.isJsonObject) continue
+                            val obj = element.asJsonObject
+                            val songId = obj.get("songId")?.asString ?: obj.get("id")?.asString ?: continue
+                            val simpleSong = obj.get("simpleSong")?.takeIf { it.isJsonObject }?.asJsonObject
+                            val realId = simpleSong?.get("id")?.asString
+
+                            if (!realId.isNullOrEmpty() && realId != "0" && realId != songId) {
+                                val cloudSongId = "cloud_$songId"
+                                if (cp.player.manager.LocalMusicManager.getBinding(cloudSongId) == null) {
+                                    val realSong = cp.player.util.JsonUtils.parseSong(simpleSong)
+                                    if (realSong != null) {
+                                        withContext(Dispatchers.Main) {
+                                            cp.player.manager.LocalMusicManager.bind(getApplication(), cloudSongId, realSong)
+                                        }
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            android.util.Log.e("UserViewModel", "Error binding simpleSong id", e)
+                        }
+                    }
+                }
             } catch (e: Exception) {
                 android.util.Log.e("UserViewModel", "Error fetching cloud songs", e)
             } finally {


### PR DESCRIPTION
This set of changes resolves an issue where custom-uploaded files to the cloud drive were stripped of their underlying reference ID to the netease music library, making fetching lyrics impossible for standard players. 

The strategy mimics the system constructed previously to support local media files: the user's personal cloud ID is mapped internally using `LocalMusicManager`. It is first populated by `UserViewModel` using hidden API details to recover the true equivalent netease ID. The `LyricsManager` is expanded to intercept requests on the modified `cloud_` prefixed IDs and proxy the fetch using the correct internal track, or performing a metadata-based text search if no binding matches exactly.

Additional interface controls were populated on the cloud music list view to expose the "Bind Cloud Song" actions to fix mismatches manually.

---
*PR created automatically by Jules for task [16796665583722672281](https://jules.google.com/task/16796665583722672281) started by @Aurora-Nasa-1*