### PR TITLE
perf: optimize lazy list keys and eliminate blocking cover extraction

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -495,18 +495,12 @@ fun AppMainContent(
                                                     name = it.songName,
                                                     artist = it.artist,
                                                     album = it.album,
-                                                    albumArtUrl = cp.player.manager.LocalMusicManager.getCoverArt(
-                                                        navContext, it.songId, it.filePath
-                                                    )
+                                                    albumArtUrl = it.albumArtUrl
                                                 )
                                             }
                                         } else {
                                             downloadViewModel.downloadedSongs.value.map { metadata ->
-                                                val coverUrl = metadata.localCoverPath
-                                                    ?: cp.player.util.CoverArtExtractor.getOrExtract(
-                                                        navContext, metadata.song.id, metadata.filePath
-                                                    )
-                                                    ?: metadata.song.albumArtUrl
+                                                val coverUrl = metadata.localCoverPath ?: metadata.song.albumArtUrl
                                                 metadata.song.copy(albumArtUrl = coverUrl)
                                             }
                                         }

--- a/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
@@ -306,7 +306,7 @@ private fun DownloadsMainContent(
                 val downloadingTasks = tasks.values.filter { it.status != DownloadStatus.COMPLETED }.toList()
                 if (downloadingTasks.isNotEmpty()) {
                     item { Text(stringResource(R.string.downloading), style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(top = 8.dp, bottom = 8.dp, start = 16.dp)) }
-                    itemsIndexed(downloadingTasks) { index, task ->
+                    itemsIndexed(downloadingTasks, key = { _, task -> task.song.id }) { index, task ->
                         SongItem(
                             song = task.song,
                             isFavorite = false,
@@ -349,7 +349,7 @@ private fun DownloadsMainContent(
                 val validDownloadedSongs = downloadedSongs.distinctBy { it.song.id }
                 if (validDownloadedSongs.isNotEmpty()) {
                     item { Text(stringResource(R.string.downloaded), style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp, start = 16.dp)) }
-                    itemsIndexed(validDownloadedSongs) { index, metadata ->
+                    itemsIndexed(validDownloadedSongs, key = { _, metadata -> metadata.song.id }) { index, metadata ->
                         val uri = if (metadata.filePath?.startsWith("content://") == true) {
                             android.net.Uri.parse(metadata.filePath)
                         } else {


### PR DESCRIPTION
This PR applies two targeted performance optimizations to the app:

1. **Jetpack Compose List Recomposition**: In `DownloadsScreen.kt`, the `itemsIndexed` loops for `downloadingTasks` and `validDownloadedSongs` lacked a stable `key`. Compose was forcing recompositions when elements were added or removed. Added `key = { _, task -> task.song.id }` and `key = { _, metadata -> metadata.song.id }` respectively to optimize scrolling and list updates.
2. **Main Thread Blocking I/O**: `MainActivity.kt` previously executed a batch `map` operation to format `localSongs` and `downloadedSongs` playlists that synchronously called `LocalMusicManager.getCoverArt` and `CoverArtExtractor.getOrExtract`. These functions leverage Android's `MediaMetadataRetriever` to extract embedded image data from files, which is a slow blocking I/O operation. Iterating this on a playlist of 50+ songs caused significant UI frame drops. The logic was restructured to just retain the `albumArtUrl` or `localCoverPath` fields in the `map`, delegating the heavy extraction work to the async `produceState` composables already handling it per-item down the UI hierarchy.

---
*PR created automatically by Jules for task [6773931061577172699](https://jules.google.com/task/6773931061577172699) started by @Aurora-Nasa-1*