### PR TITLE
Fix ANR caused by MediaMetadataRetriever on main thread

### DIFF
--- a/app/src/main/java/cp/player/manager/LocalMusicManager.kt
+++ b/app/src/main/java/cp/player/manager/LocalMusicManager.kt
@@ -118,7 +118,7 @@ object LocalMusicManager {
      *
      * @return 可供 Coil 加载的 URL 字符串（http/https 或 file://），无封面时返回 null
      */
-    fun getCoverArt(context: Context, localSongId: String, filePath: String?): String? {
+    suspend fun getCoverArt(context: Context, localSongId: String, filePath: String?): String? {
         // 1. 云端绑定封面
         val binding = bindings[localSongId]
         if (binding?.cloudCoverUrl != null) {

--- a/app/src/main/java/cp/player/util/CoverArtExtractor.kt
+++ b/app/src/main/java/cp/player/util/CoverArtExtractor.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.util.LruCache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
@@ -30,27 +32,27 @@ object CoverArtExtractor {
      *
      * @return 封面文件的 `file://` URI 字符串，无封面时返回 null
      */
-    fun getOrExtract(context: Context, songId: String, filePath: String?): String? {
-        if (filePath.isNullOrBlank()) return null
-        if (songId.isBlank()) return null
+    suspend fun getOrExtract(context: Context, songId: String, filePath: String?): String? = withContext(Dispatchers.IO) {
+        if (filePath.isNullOrBlank()) return@withContext null
+        if (songId.isBlank()) return@withContext null
 
         val normalizedId = songId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        if (normalizedId.isBlank()) return null
+        if (normalizedId.isBlank()) return@withContext null
 
         // 1. 内存缓存
         val cached = memoryCache.get(normalizedId)
-        if (cached != null) return cached.ifBlank { null }
+        if (cached != null) return@withContext cached.ifBlank { null }
 
         // 2. 磁盘缓存
         val coverFile = File(context.cacheDir, "$COVER_DIR/$normalizedId.jpg")
         if (coverFile.exists() && coverFile.length() > 0) {
             val path = "file://${coverFile.absolutePath}"
             memoryCache.put(normalizedId, path)
-            return path
+            return@withContext path
         }
 
         // 3. 从音频文件提取
-        return try {
+        return@withContext try {
             val artBytes = extractEmbeddedArt(filePath)
             if (artBytes != null) {
                 coverFile.parentFile?.mkdirs()


### PR DESCRIPTION
Fixes an ANR issue reported in Sentry where `MediaMetadataRetriever.setDataSource` was blocking the main thread.
Wrapped `CoverArtExtractor.getOrExtract` in `withContext(Dispatchers.IO)` and made it a `suspend` function. Updated caller `LocalMusicManager.getCoverArt` to be a `suspend` function as well.
Verified successfully by compiling `assembleDebug` and running `test` locally.

---
*PR created automatically by Jules for task [15993504008267930363](https://jules.google.com/task/15993504008267930363) started by @Aurora-Nasa-1*