### PR TITLE
Fix ANR by moving MediaMetadataRetriever cover art extraction to Dispatchers.IO

### DIFF
--- a/app/src/main/java/cp/player/manager/LocalMusicManager.kt
+++ b/app/src/main/java/cp/player/manager/LocalMusicManager.kt
@@ -118,7 +118,7 @@ object LocalMusicManager {
      *
      * @return 可供 Coil 加载的 URL 字符串（http/https 或 file://），无封面时返回 null
      */
-    fun getCoverArt(context: Context, localSongId: String, filePath: String?): String? {
+    suspend fun getCoverArt(context: Context, localSongId: String, filePath: String?): String? {
         // 1. 云端绑定封面
         val binding = bindings[localSongId]
         if (binding?.cloudCoverUrl != null) {

--- a/app/src/main/java/cp/player/util/CoverArtExtractor.kt
+++ b/app/src/main/java/cp/player/util/CoverArtExtractor.kt
@@ -30,27 +30,27 @@ object CoverArtExtractor {
      *
      * @return 封面文件的 `file://` URI 字符串，无封面时返回 null
      */
-    fun getOrExtract(context: Context, songId: String, filePath: String?): String? {
-        if (filePath.isNullOrBlank()) return null
-        if (songId.isBlank()) return null
+    suspend fun getOrExtract(context: Context, songId: String, filePath: String?): String? = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        if (filePath.isNullOrBlank()) return@withContext null
+        if (songId.isBlank()) return@withContext null
 
         val normalizedId = songId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        if (normalizedId.isBlank()) return null
+        if (normalizedId.isBlank()) return@withContext null
 
         // 1. 内存缓存
         val cached = memoryCache.get(normalizedId)
-        if (cached != null) return cached.ifBlank { null }
+        if (cached != null) return@withContext cached.ifBlank { null }
 
         // 2. 磁盘缓存
         val coverFile = File(context.cacheDir, "$COVER_DIR/$normalizedId.jpg")
         if (coverFile.exists() && coverFile.length() > 0) {
             val path = "file://${coverFile.absolutePath}"
             memoryCache.put(normalizedId, path)
-            return path
+            return@withContext path
         }
 
         // 3. 从音频文件提取
-        return try {
+        return@withContext try {
             val artBytes = extractEmbeddedArt(filePath)
             if (artBytes != null) {
                 coverFile.parentFile?.mkdirs()


### PR DESCRIPTION
The fix addresses an ANR reported on Sentry caused by blocking `MediaMetadataRetriever.setDataSource` calls on the UI thread when extracting cover art. `getOrExtract` and its wrapper `getCoverArt` are refactored to be suspend functions that enforce execution on `Dispatchers.IO`. All existing usages in Compose and ViewModels are already within Coroutines and cleanly adapt to these changes.

---
*PR created automatically by Jules for task [10764678505837634378](https://jules.google.com/task/10764678505837634378) started by @Aurora-Nasa-1*