### PR TITLE
Fix Error 2000 for cloud songs

### DIFF
--- a/app/src/main/java/cp/player/service/BackendDataSource.kt
+++ b/app/src/main/java/cp/player/service/BackendDataSource.kt
@@ -56,9 +56,13 @@ class BackendDataSource(
             val uri = dataSpec.uri
             DebugLog.d("CPDS: Opening URI: $uri at position ${dataSpec.position}")
 
-            val songId = if (uri.scheme == "cp") {
+            var songId = if (uri.scheme == "cp") {
                 if (uri.host == "song") uri.pathSegments.firstOrNull() else uri.host ?: uri.authority
             } else null
+
+            if (songId != null && songId.startsWith("cloud_")) {
+                songId = songId.removePrefix("cloud_")
+            }
 
             if (songId == null) {
                 val ds = when (uri.scheme) {


### PR DESCRIPTION
Fixes the issue where attempting to play a cloud song results in "Error 2000". The `cloud_` prefix on the `songId` was not being stripped prior to querying the API, causing backend URL resolution failure. Modified `BackendDataSource.kt` to appropriately extract the real `songId`.

---
*PR created automatically by Jules for task [10169581935668395936](https://jules.google.com/task/10169581935668395936) started by @Aurora-Nasa-1*