### PR TITLE
feat: allow clicking lyrics to seek to progress

### DIFF
--- a/app/src/main/java/cp/player/ui/component/LyricContent.kt
+++ b/app/src/main/java/cp/player/ui/component/LyricContent.kt
@@ -29,7 +29,8 @@ fun LyricContent(
     modifier: Modifier = Modifier,
     showTranslation: Boolean = true,
     showPhonetic: Boolean = true,
-    contentPadding: PaddingValues = PaddingValues(top = 100.dp, bottom = 600.dp, start = 24.dp, end = 24.dp)
+    contentPadding: PaddingValues = PaddingValues(top = 100.dp, bottom = 600.dp, start = 24.dp, end = 24.dp),
+    onSeek: ((Long) -> Unit)? = null
 ) {
     if (syncedLyrics == null || syncedLyrics.lines.isEmpty()) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -76,7 +77,7 @@ fun LyricContent(
         listState = listState,
         lyrics = syncedLyrics,
         currentPosition = currentPositionProvider,
-        onLineClicked = { /* 点击歌词行可扩展为跳转 */ },
+        onLineClicked = { line -> onSeek?.invoke(line.start.toLong()) },
         onLinePressed = { /* 长按歌词行可扩展为分享 */ },
         normalLineTextStyle = normalStyle,
         accompanimentLineTextStyle = accompanimentStyle,

--- a/app/src/main/java/cp/player/ui/screen/LyricsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/LyricsScreen.kt
@@ -28,7 +28,8 @@ fun LyricsScreen(
     syncedLyrics: SyncedLyrics?,
     useCoverColor: Boolean = false,
     coverColor: Int? = null,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    onSeek: (Long) -> Unit = {}
 ) {
     CoverThemeWrapper(useCoverColor = useCoverColor, coverColor = coverColor) {
         val bgBrush = if (useCoverColor && coverColor != null) {
@@ -80,7 +81,8 @@ fun LyricsScreen(
                 ) {
                     LyricContent(
                         syncedLyrics = syncedLyrics,
-                        currentPosition = currentPosition
+                        currentPosition = currentPosition,
+                        onSeek = onSeek
                     )
                 }
             }

--- a/app/src/main/java/cp/player/ui/screen/PlayerScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/PlayerScreen.kt
@@ -850,7 +850,8 @@ private fun PlayerWideLayout(
             LyricContent(
                 syncedLyrics = syncedLyrics,
                 currentPosition = currentPosition,
-                contentPadding = PaddingValues(vertical = 120.dp, horizontal = 24.dp)
+                contentPadding = PaddingValues(vertical = 120.dp, horizontal = 24.dp),
+                onSeek = onSeek
             )
         }
     }
@@ -930,7 +931,8 @@ private fun PlayerMobileLayout(
                             syncedLyrics = syncedLyrics,
                             currentPosition = currentPosition,
                             showTranslation = showTranslation,
-                            contentPadding = PaddingValues(vertical = 60.dp, horizontal = 8.dp)
+                            contentPadding = PaddingValues(vertical = 60.dp, horizontal = 8.dp),
+                            onSeek = onSeek
                         )
                     }
 


### PR DESCRIPTION
Added the ability to click on a lyric line in the UI to jump directly to that part of the song's playback progress.

- Added an `onSeek: (Long) -> Unit` parameter to `LyricContent` and `LyricsScreen`.
- Hooked up `onLineClicked` on `KaraokeLyricsView` inside `LyricContent` to invoke `onSeek` using the `ISyncedLine.start` property (in milliseconds).
- Updated usages of `LyricContent` in `PlayerScreen` to pass the existing `onSeek` callback to the lyrics component.

---
*PR created automatically by Jules for task [3360525071426232320](https://jules.google.com/task/3360525071426232320) started by @Aurora-Nasa-1*