### PR TITLE
Fix cloud songs limited to 100 by adding pagination support

### DIFF
--- a/app/src/main/java/cp/player/api/MusicApiService.kt
+++ b/app/src/main/java/cp/player/api/MusicApiService.kt
@@ -91,7 +91,7 @@ interface MusicApiService {
     suspend fun getUserDetail(uid: Long): JsonObject
 
     /** 获取用户云盘歌曲 */
-    suspend fun getUserCloud(limit: Int = 100): JsonObject
+    suspend fun getUserCloud(limit: Int = 200, offset: Int = 0): JsonObject
 
     /** 获取喜欢的音乐 ID 列表 */
     suspend fun getLikeList(uid: Long): JsonObject

--- a/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
+++ b/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
@@ -140,8 +140,8 @@ class MusicApiServiceImpl(
     override suspend fun getUserDetail(uid: Long): JsonObject =
         callApi(MusicApiMethod.USER_DETAIL, mapOf("uid" to uid.toString()))
 
-    override suspend fun getUserCloud(limit: Int): JsonObject =
-        callApi(MusicApiMethod.USER_CLOUD, mapOf("limit" to limit.toString()))
+    override suspend fun getUserCloud(limit: Int, offset: Int): JsonObject =
+        callApi(MusicApiMethod.USER_CLOUD, mapOf("limit" to limit.toString(), "offset" to offset.toString()))
 
     override suspend fun getLikeList(uid: Long): JsonObject =
         callApi(MusicApiMethod.USER_LIKE_LIST, mapOf("uid" to uid.toString()))

--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -470,44 +470,73 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                     return@launch
                 }
 
-                val body = withContext(Dispatchers.IO) { api.getUserCloud() }
-                val dataElem = body.get("data")
-                val songs = when {
-                    dataElem == null || dataElem.isJsonNull -> emptyList()
-                    // 直接是数组格式: {"data": [...]}
-                    dataElem.isJsonArray -> dataElem.asJsonArray.mapNotNull { JsonUtils.parseSong(it) }
-                    // 嵌套格式: {"data": {"data": [...], ...}}
-                    dataElem.isJsonObject -> {
-                        val innerData = dataElem.asJsonObject.get("data")
-                        if (innerData != null && innerData.isJsonArray) {
-                            innerData.asJsonArray.mapNotNull { JsonUtils.parseSong(it) }
-                        } else {
-                            // 尝试从整个 data 对象中查找数组
-                            JsonUtils.findJsonArray(dataElem, "data")?.mapNotNull { JsonUtils.parseSong(it) }
-                                ?: emptyList()
+                val allSongs = mutableListOf<Song>()
+                val allElements = mutableListOf<com.google.gson.JsonElement>()
+                val seenIds = mutableSetOf<String>()
+                var offset = 0
+                val limit = 200
+
+                withContext(Dispatchers.IO) {
+                    while (true) {
+                        val body = api.getUserCloud(limit = limit, offset = offset)
+                        val dataElem = body.get("data")
+
+                        val songs = when {
+                            dataElem == null || dataElem.isJsonNull -> emptyList()
+                            // 直接是数组格式: {"data": [...]}
+                            dataElem.isJsonArray -> dataElem.asJsonArray.mapNotNull { JsonUtils.parseSong(it) }
+                            // 嵌套格式: {"data": {"data": [...], ...}}
+                            dataElem.isJsonObject -> {
+                                val innerData = dataElem.asJsonObject.get("data")
+                                if (innerData != null && innerData.isJsonArray) {
+                                    innerData.asJsonArray.mapNotNull { JsonUtils.parseSong(it) }
+                                } else {
+                                    // 尝试从整个 data 对象中查找数组
+                                    JsonUtils.findJsonArray(dataElem, "data")?.mapNotNull { JsonUtils.parseSong(it) }
+                                        ?: emptyList()
+                                }
+                            }
+                            else -> emptyList()
                         }
+
+                        val elements = when {
+                            dataElem == null || dataElem.isJsonNull -> emptyList()
+                            dataElem.isJsonArray -> dataElem.asJsonArray.toList()
+                            dataElem.isJsonObject -> {
+                                val innerData = dataElem.asJsonObject.get("data")
+                                if (innerData != null && innerData.isJsonArray) {
+                                    innerData.asJsonArray.toList()
+                                } else {
+                                    cp.player.util.JsonUtils.findJsonArray(dataElem, "data")?.toList() ?: emptyList()
+                                }
+                            }
+                            else -> emptyList()
+                        }
+
+                        if (songs.isEmpty()) break
+
+                        var addedNew = false
+                        for (song in songs) {
+                            if (seenIds.add(song.id)) {
+                                allSongs.add(song)
+                                addedNew = true
+                            }
+                        }
+
+                        allElements.addAll(elements)
+
+                        // 某些 provider 可能不支持 offset 返回重复数据，或者已经返回所有数据
+                        if (!addedNew || songs.size < limit) break
+
+                        offset += limit
                     }
-                    else -> emptyList()
                 }
-                cloudSongs = songs
+
+                cloudSongs = allSongs
 
                 // Extract simpleSong.id and bind it
                 withContext(Dispatchers.IO) {
-                    val elements = when {
-                        dataElem == null || dataElem.isJsonNull -> emptyList()
-                        dataElem.isJsonArray -> dataElem.asJsonArray.toList()
-                        dataElem.isJsonObject -> {
-                            val innerData = dataElem.asJsonObject.get("data")
-                            if (innerData != null && innerData.isJsonArray) {
-                                innerData.asJsonArray.toList()
-                            } else {
-                                cp.player.util.JsonUtils.findJsonArray(dataElem, "data")?.toList() ?: emptyList()
-                            }
-                        }
-                        else -> emptyList()
-                    }
-
-                    for (element in elements) {
+                    for (element in allElements) {
                         try {
                             if (!element.isJsonObject) continue
                             val obj = element.asJsonObject


### PR DESCRIPTION
Modified `getUserCloud` in `MusicApiService` and `MusicApiServiceImpl` to accept an `offset` parameter, and updated `UserViewModel.fetchCloudSongs` to use a pagination loop. This allows the app to fetch and display all songs from the cloud drive, overcoming the previous 100-song limit. Added safety check to prevent infinite loop if backend does not support offset.

---
*PR created automatically by Jules for task [6627997411947012715](https://jules.google.com/task/6627997411947012715) started by @Aurora-Nasa-1*