### PR TITLE
Refactor color extraction and theming to use Material Color Utilities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,6 +171,9 @@ dependencies {
     implementation(libs.accompanist.lyrics.core)
     implementation(libs.gaze.capsule)
 
+    // Material Color Utilities for Monet-like extraction
+    implementation(libs.material.color.utilities)
+
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core

--- a/app/src/main/java/cp/player/ui/component/FluidBackground.kt
+++ b/app/src/main/java/cp/player/ui/component/FluidBackground.kt
@@ -72,14 +72,14 @@ private const val FLUID_SHADER = """
         color += dither(fragCoord);
 
         if (iLightMode < 0.5) {
-            float3 baseLight = float3(0.98, 0.96, 0.95);
-            color = mix(baseLight, color, 0.45);
-            color = clamp(color * 1.05, 0.0, 1.0);
+            float3 baseLight = float3(0.98, 0.98, 0.98); // pure soft light background
+            color = mix(baseLight, color, 0.25); // drastically reduce opacity for ultra soft pastel look
+            color = clamp(color, 0.0, 1.0);
             return half4(color, 1.0);
         } else {
-            float3 baseDark = float3(0.08, 0.09, 0.12);
-            color = mix(baseDark, color, 0.55);
-            color = smoothstep(0.0, 1.2, color);
+            float3 baseDark = float3(0.05, 0.05, 0.07); // deep space dark background
+            color = mix(baseDark, color, 0.35); // significantly soften dark mode too to ensure readability
+            color = clamp(color, 0.0, 1.0);
             return half4(color, 1.0);
         }
     }
@@ -107,9 +107,9 @@ fun FluidBackground(
         )
 
         val colors = if (isDark) {
-            listOf(color.copy(alpha = 0.6f), color.copy(alpha = 0.2f), Color.Black)
+            listOf(color.copy(alpha = 0.35f), color.copy(alpha = 0.15f), Color(0xFF121212))
         } else {
-            listOf(color.copy(alpha = 0.1f), color.copy(alpha = 0.05f), Color.White)
+            listOf(color.copy(alpha = 0.15f), color.copy(alpha = 0.05f), Color(0xFFF8F8F8))
         }
 
         Box(
@@ -146,28 +146,34 @@ private fun AgslFluidBackground(
     )
 
     // Monet-inspired complementary colors for fluid effect: soft, pastel-like transition
-    val color1 = color
+    // By reducing the saturation dramatically here, we guarantee a "Monet" soft aesthetic
+    val color1 = remember(color) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(color.toArgb(), hsv)
+        hsv[1] = (hsv[1] * 0.7f).coerceAtMost(0.6f) // Limit saturation
+        Color.hsv(hsv[0], hsv[1], hsv[2])
+    }
     val color2 = remember(color) {
         val hsv = FloatArray(3)
         android.graphics.Color.colorToHSV(color.toArgb(), hsv)
         hsv[0] = (hsv[0] + 25) % 360
-        hsv[1] = (hsv[1] * 0.6f).coerceIn(0.2f, 0.6f) // Softer saturation for Monet feel
+        hsv[1] = (hsv[1] * 0.5f).coerceAtMost(0.5f)
         Color.hsv(hsv[0], hsv[1], hsv[2])
     }
     val color3 = remember(color) {
         val hsv = FloatArray(3)
         android.graphics.Color.colorToHSV(color.toArgb(), hsv)
         hsv[0] = (hsv[0] - 20 + 360) % 360
-        hsv[1] = (hsv[1] * 0.7f).coerceIn(0.2f, 0.7f)
-        hsv[2] = (hsv[2] * 0.85f).coerceIn(0.3f, 0.9f)
+        hsv[1] = (hsv[1] * 0.6f).coerceAtMost(0.6f)
+        hsv[2] = (hsv[2] * 0.9f).coerceIn(0.4f, 0.9f)
         Color.hsv(hsv[0], hsv[1], hsv[2])
     }
     val color4 = remember(color) {
         val hsv = FloatArray(3)
         android.graphics.Color.colorToHSV(color.toArgb(), hsv)
         hsv[0] = (hsv[0] + 180) % 360 // Complementary contrast hue
-        hsv[1] = (hsv[1] * 0.4f).coerceIn(0.1f, 0.4f)
-        hsv[2] = (hsv[2] * 0.9f).coerceIn(0.4f, 1f)
+        hsv[1] = (hsv[1] * 0.3f).coerceAtMost(0.3f)
+        hsv[2] = (hsv[2] * 0.95f).coerceIn(0.5f, 1f)
         Color.hsv(hsv[0], hsv[1], hsv[2])
     }
 

--- a/app/src/main/java/cp/player/ui/theme/Theme.kt
+++ b/app/src/main/java/cp/player/ui/theme/Theme.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.materialkolor.dynamicColorScheme
 import androidx.compose.ui.graphics.Color
 import cp.player.R
 
@@ -114,51 +115,14 @@ fun createGoogleSansFlex(roundnessMode: Int): FontFamily {
 private val DarkColorScheme = darkColorScheme()
 private val LightColorScheme = lightColorScheme()
 
+@Composable
 fun createCustomColorScheme(seedColor: Int, isDark: Boolean, pureBlack: Boolean = false): ColorScheme {
-    val color = Color(seedColor)
-    val luminance = androidx.core.graphics.ColorUtils.calculateLuminance(seedColor)
-    val isDarkSeed = luminance < 0.5
-
-    return if (isDark) {
-        darkColorScheme(
-            primary = color,
-            onPrimary = if (isDarkSeed) Color.White else Color.Black,
-            primaryContainer = color.copy(alpha = 0.3f),
-            onPrimaryContainer = Color.White,
-            secondary = color.copy(alpha = 0.5f),
-            onSecondary = Color.White,
-            secondaryContainer = if (pureBlack) Color(0xFF121212) else color.copy(alpha = 0.2f),
-            onSecondaryContainer = Color.White,
-            surface = if (pureBlack) Color.Black else Color(0xFF121212),
-            onSurface = Color.White,
-            background = if (pureBlack) Color.Black else Color(0xFF121212),
-            onBackground = Color.White,
-            surfaceVariant = if (pureBlack) Color.Black else color.copy(alpha = 0.1f),
-            onSurfaceVariant = Color.White,
-            surfaceContainerLowest = if (pureBlack) Color.Black else Color(0xFF0D0D0D),
-            surfaceContainerLow = if (pureBlack) Color.Black else Color(0xFF1A1A1A),
-            surfaceContainer = if (pureBlack) Color.Black else Color(0xFF1F1F1F),
-            surfaceContainerHigh = if (pureBlack) Color.Black else Color(0xFF232323),
-            surfaceContainerHighest = if (pureBlack) Color.Black else Color(0xFF282828)
-        )
-    } else {
-        lightColorScheme(
-            primary = color,
-            onPrimary = if (isDarkSeed) Color.White else Color.Black,
-            primaryContainer = color.copy(alpha = 0.2f),
-            onPrimaryContainer = color,
-            secondary = color.copy(alpha = 0.6f),
-            onSecondary = Color.White,
-            secondaryContainer = color.copy(alpha = 0.1f),
-            onSecondaryContainer = color,
-            surface = Color(0xFFFDFDFD),
-            onSurface = Color.Black,
-            background = Color(0xFFFDFDFD),
-            onBackground = Color.Black,
-            surfaceVariant = color.copy(alpha = 0.05f),
-            onSurfaceVariant = Color.Black
-        )
-    }
+    val baseScheme = dynamicColorScheme(
+        seedColor = Color(seedColor),
+        isDark = isDark,
+        isAmoled = pureBlack
+    )
+    return baseScheme
 }
 
 @Composable

--- a/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
+++ b/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
@@ -7,7 +7,10 @@ import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
 import coil3.toBitmap
+import com.materialkolor.ktx.themeColor
 import cp.player.manager.DownloadRegistry
 import cp.player.model.Song
 import cp.player.util.DebugLog
@@ -30,9 +33,22 @@ class MediaMetadataUseCase(private val application: Application) {
             val result = loader.execute(request)
             if (result is SuccessResult) {
                 val bitmap = result.image.toBitmap()
+
+                // Fallback using Palette in case MCU fails
+                var fallbackColor = 0
                 val palette = Palette.from(bitmap).generate()
-                val color = palette.getDominantColor(palette.getVibrantColor(palette.getMutedColor(0)))
-                if (color != 0) return@withContext color
+                fallbackColor = palette.getDominantColor(palette.getVibrantColor(palette.getMutedColor(0)))
+
+                // Use official Material Color Utilities for Monet extraction
+                try {
+                    val imageBitmap = bitmap.asImageBitmap()
+                    val themeColor = imageBitmap.themeColor(fallback = androidx.compose.ui.graphics.Color(fallbackColor))
+                    return@withContext themeColor.toArgb()
+                } catch (e: Exception) {
+                    DebugLog.e("Material Color Utilities extraction failed: ${e.message}")
+                }
+
+                if (fallbackColor != 0) return@withContext fallbackColor
             }
         } catch (e: Exception) {
             DebugLog.e("Palette extraction failed: ${e.message}")

--- a/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
+++ b/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
@@ -42,8 +42,11 @@ class MediaMetadataUseCase(private val application: Application) {
                 // Use official Material Color Utilities for Monet extraction
                 try {
                     val imageBitmap = bitmap.asImageBitmap()
-                    val themeColor = imageBitmap.themeColor(fallback = androidx.compose.ui.graphics.Color(fallbackColor))
-                    return@withContext themeColor.toArgb()
+                    // Default to black (opaque) if fallbackColor is 0, to avoid passing transparent black (0) as fallback.
+                    val safeFallback = if (fallbackColor != 0) androidx.compose.ui.graphics.Color(fallbackColor) else androidx.compose.ui.graphics.Color.Black
+                    val themeColor = imageBitmap.themeColor(fallback = safeFallback)
+                    val argb = themeColor.toArgb()
+                    if (argb != 0) return@withContext argb
                 } catch (e: Exception) {
                     DebugLog.e("Material Color Utilities extraction failed: ${e.message}")
                 }

--- a/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
@@ -215,7 +215,7 @@ class PlaybackViewModel(application: Application) : BaseViewModel(application) {
         viewModelScope.launch(Dispatchers.IO) {
             val color = mediaMetadataUseCase.extractColorFromUrl(url)
             withContext(Dispatchers.Main) {
-                if (color != null) {
+                if (color != null && color != 0) {
                     extractedColor = color
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ accompanist-lyrics-ui = "1.0.19"
 accompanist-lyrics-core = "0.4.5"
 gaze-capsule = "2.1.1-patch2"
 androidx-window = "1.3.0"
+material-color-utilities = "2.0.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -56,6 +57,7 @@ accompanist-lyrics-ui = { module = "com.mocharealm.accompanist:lyrics-ui", versi
 accompanist-lyrics-core = { module = "com.mocharealm.accompanist:lyrics-core", version.ref = "accompanist-lyrics-core" }
 gaze-capsule = { module = "com.mocharealm.gaze:capsule", version.ref = "gaze-capsule" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
+material-color-utilities = { module = "com.materialkolor:material-kolor", version.ref = "material-color-utilities" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Replaced basic Palette extraction with native Material Color Utilities extraction using `com.materialkolor`. This mimics the official Monet extraction style for significantly softer, better contrasting dynamically-themed components. Also tuned the Fluid Background shader heavily to restrict saturation and soften the rendering for readability.

---
*PR created automatically by Jules for task [11156634368201433498](https://jules.google.com/task/11156634368201433498) started by @Aurora-Nasa-1*