### PR TITLE
Refactor `JsonUtils.kt` with safe Kotlin extension properties

### DIFF
--- a/app/src/main/java/cp/player/util/JsonUtils.kt
+++ b/app/src/main/java/cp/player/util/JsonUtils.kt
@@ -11,40 +11,47 @@ import cp.player.model.Comment
 import cp.player.model.Playlist
 
 object JsonUtils {
+
+private val JsonElement?.obj: JsonObject? get() = if (this?.isJsonObject == true) this.asJsonObject else null
+private val JsonElement?.arr: JsonArray? get() = if (this?.isJsonArray == true) this.asJsonArray else null
+private val JsonElement?.str: String? get() = if (this?.isJsonPrimitive == true) this.asString else null
+private val JsonElement?.long: Long? get() = try { if (this?.isJsonPrimitive == true) this.asLong else null } catch (e: NumberFormatException) { null }
+private val JsonElement?.int: Int? get() = try { if (this?.isJsonPrimitive == true) this.asInt else null } catch (e: NumberFormatException) { null }
+private val JsonElement?.bool: Boolean? get() = if (this?.isJsonPrimitive == true && this.asJsonPrimitive.isBoolean) this.asBoolean else null
+
+
     fun parseSong(it: JsonElement): Song? {
-        return try {
-            val item = it.asJsonObject
+        val item = it.obj ?: return null
 
-            // Check for cloud song format first
-            if (item.has("songId") && item.has("songName")) {
-                return parseCloudSongItem(item)
-            }
-
-            val obj = if (item.has("songInfo")) item.get("songInfo").asJsonObject else item
-
-            val artists = obj.get("ar")?.asJsonArray ?: obj.get("artists")?.asJsonArray
-            val artistObj = artists?.get(0)?.asJsonObject
-            val artistName = artistObj?.get("name")?.asString ?: "Unknown"
-            val artistId = artistObj?.get("id")?.asString
-            val album = obj.get("al")?.asJsonObject ?: obj.get("album")?.asJsonObject
-            val albumName = album?.get("name")?.asString ?: "Unknown"
-            var picUrl = album?.get("picUrl")?.asString
-            if (picUrl == null || picUrl.contains("null")) {
-                picUrl = findUrl(obj)
-            }
-
-            Song(
-                id = (obj.get("id") ?: obj.get("songId")).asJsonPrimitive.asString,
-                name = obj.get("name").asString,
-                artist = artistName,
-                artistId = artistId,
-                album = albumName,
-                albumArtUrl = picUrl,
-                durationMs = obj.get("dt")?.asLong ?: obj.get("duration")?.asLong ?: 0L
-            )
-        } catch (e: Exception) {
-            null
+        if (item.has("songId") && item.has("songName")) {
+            return parseCloudSongItem(item)
         }
+
+        val obj = item.get("songInfo").obj ?: item
+
+        val artists = obj.get("ar").arr ?: obj.get("artists").arr
+        val artistObj = artists?.get(0).obj
+        val artistName = artistObj?.get("name").str ?: "Unknown"
+        val artistId = artistObj?.get("id").str
+        val album = obj.get("al").obj ?: obj.get("album").obj
+        val albumName = album?.get("name").str ?: "Unknown"
+        var picUrl = album?.get("picUrl").str
+        if (picUrl == null || picUrl.contains("null")) {
+            picUrl = findUrl(obj)
+        }
+
+        val id = obj.get("id").str ?: obj.get("songId").str ?: return null
+        val name = obj.get("name").str ?: return null
+
+        return Song(
+            id = id,
+            name = name,
+            artist = artistName,
+            artistId = artistId,
+            album = albumName,
+            albumArtUrl = picUrl,
+            durationMs = obj.get("dt").long ?: obj.get("duration").long ?: 0L
+        )
     }
 
     /**
@@ -55,163 +62,138 @@ object JsonUtils {
      * 优先从嵌套的 `simpleSong` 中提取封面。
      */
     fun parseCloudSongItem(item: com.google.gson.JsonObject): Song? {
-        return try {
-            val songId = (item.get("songId") ?: item.get("id"))?.asString ?: return null
-            val songName = item.get("songName")?.asString ?: "Unknown"
-            val artist = item.get("artist")?.asString ?: "Unknown"
-            val album = item.get("album")?.asString ?: "Cloud Storage"
-            // 尝试从 simpleSong 中获取封面
-            val simpleSong = item.get("simpleSong")?.takeIf { it.isJsonObject }?.asJsonObject
-            val picUrl = simpleSong?.let { ss ->
-                ss.get("al")?.asJsonObject?.get("picUrl")?.asString
-                    ?: ss.get("album")?.asJsonObject?.get("picUrl")?.asString
-            }
-            val duration = item.get("dt")?.asLong ?: item.get("duration")?.asLong
-                ?: simpleSong?.get("dt")?.asLong ?: 0L
+        val songId = item.get("songId").str ?: item.get("id").str ?: return null
+        val songName = item.get("songName").str ?: "Unknown"
+        val artist = item.get("artist").str ?: "Unknown"
+        val album = item.get("album").str ?: "Cloud Storage"
 
-            Song(
-                id = "cloud_$songId",
-                name = songName,
-                artist = artist,
-                album = album,
-                albumArtUrl = picUrl,
-                durationMs = duration
-            )
-        } catch (e: Exception) {
-            null
+        val simpleSong = item.get("simpleSong").obj
+        val picUrl = simpleSong?.let { ss ->
+            ss.get("al").obj?.get("picUrl").str ?: ss.get("album").obj?.get("picUrl").str
         }
+        val duration = item.get("dt").long ?: item.get("duration").long ?: simpleSong?.get("dt").long ?: 0L
+
+        return Song(
+            id = "cloud_$songId",
+            name = songName,
+            artist = artist,
+            album = album,
+            albumArtUrl = picUrl,
+            durationMs = duration
+        )
     }
 
     fun parseComment(it: JsonElement): Comment? {
-        return try {
-            val obj = it.asJsonObject
-            val user = obj.get("user")?.asJsonObject ?: obj.get("author")?.asJsonObject ?: return null
-            val beReplied = obj.get("beReplied")?.asJsonArray?.mapNotNull {
-                val replyObj = it.asJsonObject
-                val replyUser = replyObj.get("user")?.asJsonObject
-                if (replyUser != null) {
-                    Comment.Reply(
-                        userId = replyUser.get("userId")?.asLong ?: 0L,
-                        nickname = replyUser.get("nickname")?.asString ?: "Unknown",
-                        content = replyObj.get("content")?.asString ?: ""
-                    )
-                } else null
-            }
-
-            Comment(
-                id = (obj.get("commentId") ?: obj.get("id")).asLong,
-                userId = user.get("userId").asLong,
-                nickname = user.get("nickname").asString,
-                avatarUrl = user.get("avatarUrl").asString,
-                content = obj.get("content")?.asString ?: "",
-                time = obj.get("time").asLong,
-                timeStr = obj.get("timeStr")?.asString ?: "",
-                likedCount = obj.get("likedCount")?.asInt ?: 0,
-                liked = obj.get("liked")?.asBoolean ?: false,
-                replyCount = obj.get("replyCount")?.asInt ?: 0,
-                beReplied = beReplied
-            )
-        } catch (e: Exception) {
-            null
+        val obj = it.obj ?: return null
+        val user = obj.get("user").obj ?: obj.get("author").obj ?: return null
+        val beReplied = obj.get("beReplied").arr?.mapNotNull { replyElement ->
+            val replyObj = replyElement.obj
+            val replyUser = replyObj?.get("user").obj
+            if (replyUser != null) {
+                Comment.Reply(
+                    userId = replyUser.get("userId").long ?: 0L,
+                    nickname = replyUser.get("nickname").str ?: "Unknown",
+                    content = replyObj?.get("content").str ?: ""
+                )
+            } else null
         }
+
+        val id = obj.get("commentId").long ?: obj.get("id").long ?: return null
+        val userId = user.get("userId").long ?: return null
+        val nickname = user.get("nickname").str ?: return null
+        val avatarUrl = user.get("avatarUrl").str ?: return null
+        val time = obj.get("time").long ?: return null
+
+        return Comment(
+            id = id,
+            userId = userId,
+            nickname = nickname,
+            avatarUrl = avatarUrl,
+            content = obj.get("content").str ?: "",
+            time = time,
+            timeStr = obj.get("timeStr").str ?: "",
+            likedCount = obj.get("likedCount").int ?: 0,
+            liked = obj.get("liked").bool ?: false,
+            replyCount = obj.get("replyCount").int ?: 0,
+            beReplied = beReplied
+        )
     }
 
     fun parseContact(it: JsonElement): Contact? {
-        return try {
-            val obj = it.asJsonObject
+        val obj = it.obj ?: return null
 
-            // Handle different variations of where user info might be stored
-            val fromUser = when {
-                obj.has("fromUser") && obj.get("fromUser").isJsonObject -> obj.get("fromUser").asJsonObject
-                obj.has("from") && obj.get("from").isJsonObject -> obj.get("from").asJsonObject
-                obj.has("user") && obj.get("user").isJsonObject -> obj.get("user").asJsonObject
-                obj.has("author") && obj.get("author").isJsonObject -> obj.get("author").asJsonObject
-                obj.has("profile") && obj.get("profile").isJsonObject -> obj.get("profile").asJsonObject
-                else -> null
-            }
+        val fromUser = obj.get("fromUser").obj ?: obj.get("from").obj ?: obj.get("user").obj ?: obj.get("author").obj ?: obj.get("profile").obj
+        val lastMsgStr = obj.get("lastMsg").str ?: obj.get("msg").str ?: ""
 
-            val lastMsgStr = when {
-                obj.has("lastMsg") && obj.get("lastMsg").isJsonPrimitive -> obj.get("lastMsg").asString
-                obj.has("msg") && obj.get("msg").isJsonPrimitive -> obj.get("msg").asString
-                else -> ""
-            }
+        val lastMsgObj = if (lastMsgStr.startsWith("{")) {
+            try { com.google.gson.JsonParser.parseString(lastMsgStr).obj } catch (e: Exception) { null }
+        } else null
 
-            val lastMsgObj = try {
-                if (lastMsgStr.startsWith("{")) JsonParser.parseString(lastMsgStr).asJsonObject else null
-            } catch (e: Exception) { null }
+        val messageText = lastMsgObj?.get("msg").str ?: lastMsgStr
 
-            val messageText = lastMsgObj?.get("msg")?.asString ?: lastMsgStr
-
-            Contact(
-                userId = fromUser?.get("userId")?.asLong ?: fromUser?.get("id")?.asLong ?: 0L,
-                nickname = fromUser?.get("nickname")?.asString ?: fromUser?.get("userName")?.asString ?: "Unknown",
-                avatarUrl = fromUser?.get("avatarUrl")?.asString ?: "",
-                lastMessage = messageText,
-                lastMessageTime = obj.get("lastMsgTime")?.asLong ?: obj.get("time")?.asLong ?: 0L,
-                unreadCount = obj.get("newMsgCount")?.asInt ?: 0
-            )
-        } catch (e: Exception) {
-            null
-        }
+        return Contact(
+            userId = fromUser?.get("userId").long ?: fromUser?.get("id").long ?: 0L,
+            nickname = fromUser?.get("nickname").str ?: fromUser?.get("userName").str ?: "Unknown",
+            avatarUrl = fromUser?.get("avatarUrl").str ?: "",
+            lastMessage = messageText,
+            lastMessageTime = obj.get("lastMsgTime").long ?: obj.get("time").long ?: 0L,
+            unreadCount = obj.get("newMsgCount").int ?: 0
+        )
     }
 
     fun parsePlaylist(element: JsonElement): Playlist? {
-        return try {
-            val obj = element.asJsonObject
-            val creatorObj = obj.get("creator")?.takeIf { it.isJsonObject }?.asJsonObject
-            val creatorUserId = creatorObj?.get("userId")?.takeIf { !it.isJsonNull }?.asLong ?: 0L
-            val subscribed = obj.get("subscribed")?.takeIf { !it.isJsonNull }?.asBoolean ?: false
-            Playlist(
-                id = obj.get("id")?.takeIf { !it.isJsonNull }?.asLong ?: 0L,
-                name = getString(obj, "name") ?: "",
-                coverImgUrl = getString(obj, "coverImgUrl") ?: getString(obj, "picUrl"),
-                trackCount = if (obj.has("trackCount") && !obj.get("trackCount").isJsonNull) obj.get("trackCount").asInt else 0,
-                creatorName = getString(creatorObj, "nickname"),
-                creatorUserId = creatorUserId,
-                subscribed = subscribed,
-                description = getString(obj, "description")
-            )
-        } catch (e: Exception) { null }
+        val obj = element.obj ?: return null
+        val creatorObj = obj.get("creator").obj
+        val creatorUserId = creatorObj?.get("userId").long ?: 0L
+        val subscribed = obj.get("subscribed").bool ?: false
+        val id = obj.get("id").long ?: return null
+
+        return Playlist(
+            id = id,
+            name = getString(obj, "name") ?: "",
+            coverImgUrl = getString(obj, "coverImgUrl") ?: getString(obj, "picUrl"),
+            trackCount = obj.get("trackCount").int ?: 0,
+            creatorName = getString(creatorObj, "nickname"),
+            creatorUserId = creatorUserId,
+            subscribed = subscribed,
+            description = getString(obj, "description")
+        )
     }
 
     fun parseMessage(it: JsonElement, myUserId: Long): Message? {
-        return try {
-            val obj = it.asJsonObject
-            val fromUser = obj.get("fromUser").asJsonObject
-            val msgStr = obj.get("msg")?.asString ?: "{}"
-            val msgContent = try { JsonParser.parseString(msgStr).asJsonObject } catch (e: Exception) { JsonObject() }
-            val userId = fromUser.get("userId").asLong
+        val obj = it.obj ?: return null
+        val fromUser = obj.get("fromUser").obj ?: return null
+        val msgStr = obj.get("msg").str ?: "{}"
+        val msgContent = try { com.google.gson.JsonParser.parseString(msgStr).obj } catch (e: Exception) { null }
+        val userId = fromUser.get("userId").long ?: return null
 
-            Message(
-                id = obj.get("id").asLong,
-                fromUserId = userId,
-                fromNickname = fromUser.get("nickname").asString,
-                fromAvatarUrl = fromUser.get("avatarUrl").asString,
-                text = msgContent.get("msg")?.asString ?: "",
-                time = obj.get("time").asLong,
-                isMe = userId == myUserId
-            )
-        } catch (e: Exception) {
-            null
-        }
+        val id = obj.get("id").long ?: return null
+        val fromNickname = fromUser.get("nickname").str ?: return null
+        val fromAvatarUrl = fromUser.get("avatarUrl").str ?: return null
+        val time = obj.get("time").long ?: return null
+
+        return Message(
+            id = id,
+            fromUserId = userId,
+            fromNickname = fromNickname,
+            fromAvatarUrl = fromAvatarUrl,
+            text = msgContent?.get("msg").str ?: "",
+            time = time,
+            isMe = userId == myUserId
+        )
     }
 
     fun getString(element: JsonElement?, key: String, default: String? = null): String? {
-        val obj = if (element != null && element.isJsonObject) element.asJsonObject else return default
-        val field = obj.get(key)
-        return if (field != null && !field.isJsonNull && field.isJsonPrimitive) field.asString else default
+        val obj = element.obj ?: return default
+        return obj.get(key).str ?: default
     }
 
     fun findUrl(element: JsonElement?): String? {
-        if (element == null || element.isJsonNull) return null
-
-        if (element.isJsonPrimitive && element.asJsonPrimitive.isString) {
-            val s = element.asString
+        element.str?.let { s ->
             if (s.startsWith("http") && s.length > 12 && !s.contains("null")) return s
         }
 
-        if (element.isJsonObject) {
-            val obj = element.asJsonObject
+        element.obj?.let { obj ->
             // Direct check
             val url = getString(obj, "url") ?: getString(obj, "picUrl") ?: getString(obj, "coverImgUrl") ?: getString(obj, "avatarUrl")
             if (url != null && url.startsWith("http") && url.length > 12 && !url.contains("null")) return url
@@ -225,25 +207,21 @@ object JsonUtils {
             return obj.entrySet().firstNotNullOfOrNull { findUrl(it.value) }
         }
 
-        if (element.isJsonArray) {
-            return element.asJsonArray.firstNotNullOfOrNull { findUrl(it) }
+        element.arr?.let { arr ->
+            return arr.firstNotNullOfOrNull { findUrl(it) }
         }
 
         return null
     }
 
     fun findJsonArray(element: JsonElement?, key: String): JsonArray? {
-        if (element == null || element.isJsonNull) return null
-
-        if (element.isJsonObject) {
-            val obj = element.asJsonObject
-            if (obj.has(key) && obj.get(key).isJsonArray) return obj.getAsJsonArray(key)
-
+        element.obj?.let { obj ->
+            obj.get(key).arr?.let { return it }
             return obj.entrySet().firstNotNullOfOrNull { findJsonArray(it.value, key) }
         }
 
-        if (element.isJsonArray) {
-            return element.asJsonArray.firstNotNullOfOrNull { findJsonArray(it, key) }
+        element.arr?.let { arr ->
+            return arr.firstNotNullOfOrNull { findJsonArray(it, key) }
         }
 
         return null


### PR DESCRIPTION
This change targets the `JsonUtils.kt` utility file to simplify and optimize JSON parsing operations across the `CPPlayer` application.

Previously, JSON parsing relied on raw Gson calls (like `.asJsonObject`, `.asString`, `.asLong`) wrapped in large `try-catch` blocks. These raw calls are prone to throwing exceptions on type mismatches. As noted in the project's memory, this could be improved by using safe Kotlin extension properties.

I implemented `.obj`, `.arr`, `.str`, `.long`, `.int`, and `.bool` on `JsonElement?`. These properties internally check if the `JsonElement` is the correct primitive or object/array type before making the conversion and handle parsing using safe nulls (`?`). 

I then refactored the primary parsing methods (`parseSong`, `parseCloudSongItem`, `parseComment`, `parseContact`, `parsePlaylist`, and `parseMessage`) as well as the helper methods (`getString`, `findUrl`, `findJsonArray`) to use these properties. The large `try-catch` blocks were removed, resulting in a cleaner, safer, and structurally concise `JsonUtils.kt` file.

During the pre-commit review, a bug in `.str` was caught where it rejected JSON Numbers (which need to be parsed as Strings for song IDs). This was corrected, and tests pass successfully.

---
*PR created automatically by Jules for task [10945697564512598740](https://jules.google.com/task/10945697564512598740) started by @Aurora-Nasa-1*