### PR TITLE
feat: integrate SuperLyricApi for real-time lyric broadcasting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,6 +174,8 @@ dependencies {
     // Material Color Utilities for Monet-like extraction
     implementation(libs.material.color.utilities)
 
+    implementation(libs.superlyricapi)
+
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,3 +33,8 @@
 
 # Compose FontVariation inner classes (used via reflection for custom ROND axis)
 -keep class androidx.compose.ui.text.font.FontVariation$** { *; }
+
+# SuperLyricApi
+-keep class com.hchen.superlyricapi.** {*;}
+
+-dontwarn android.os.ServiceManager

--- a/app/src/main/java/cp/player/service/MusicService.kt
+++ b/app/src/main/java/cp/player/service/MusicService.kt
@@ -34,6 +34,10 @@ import cp.player.util.DebugLog
 import io.github.proify.lyricon.provider.LyriconFactory
 import io.github.proify.lyricon.provider.LyriconProvider
 import io.github.proify.lyricon.lyric.model.Song
+import com.hchen.superlyricapi.SuperLyricData
+import com.hchen.superlyricapi.SuperLyricHelper
+import com.hchen.superlyricapi.SuperLyricLine
+import com.hchen.superlyricapi.SuperLyricWord
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -127,6 +131,13 @@ class MusicService : MediaSessionService() {
     private var lyriconProvider: LyriconProvider? = null
     private var lyricJob: Job? = null
     private var playbackInfoJob: Job? = null
+
+    // SuperLyric state
+    private var currentSuperLyricLines: List<io.github.proify.lyricon.lyric.model.RichLyricLine>? = null
+    private var currentSuperLyricIndex: Int = -1
+    private var currentSuperLyricTitle: String = ""
+    private var currentSuperLyricArtist: String = ""
+    private var currentSuperLyricAlbum: String = ""
     private val likedSongIds = mutableSetOf<String>()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -279,6 +290,9 @@ class MusicService : MediaSessionService() {
         super.onCreate()
         DebugLog.i("MusicService: Service onCreate")
 
+        SuperLyricHelper.registerPublisher()
+        SuperLyricHelper.setSystemPlayStateListenerEnabled(false)
+
         usbAudioManager = UsbAudioManager(this)
         usbAudioManager?.start()
         audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -313,6 +327,9 @@ class MusicService : MediaSessionService() {
                     updateMediaSessionLayout()
                     updateWidget()
                     lyriconProvider?.player?.setPlaybackState(isPlaying)
+                    if (!isPlaying) {
+                        SuperLyricHelper.sendStop(SuperLyricData())
+                    }
                 }
 
                 override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -537,6 +554,9 @@ class MusicService : MediaSessionService() {
                     updateMediaSessionLayout()
                     updateWidget()
                     lyriconProvider?.player?.setPlaybackState(isPlaying)
+                    if (!isPlaying) {
+                        SuperLyricHelper.sendStop(SuperLyricData())
+                    }
                 }
                 override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                     if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
@@ -629,6 +649,7 @@ class MusicService : MediaSessionService() {
                 val p = activePlayer
                 if (p != null && p.isPlaying) {
                     lyriconProvider?.player?.setPosition(p.currentPosition)
+                    syncSuperLyric(p.currentPosition)
                     
                     if (!crossfadeManager.isCrossfading) {
                         val dur = p.duration
@@ -661,6 +682,59 @@ class MusicService : MediaSessionService() {
                 }
                 delay(100)
             }
+        }
+    }
+
+    private fun syncSuperLyric(position: Long) {
+        val lines = currentSuperLyricLines ?: return
+        var newIndex = -1
+        for (i in lines.indices) {
+            val line = lines[i]
+            if (position >= line.begin && (line.end == 0L || position < line.end)) {
+                newIndex = i
+                break
+            } else if (position < line.begin) {
+                // Since lyrics are usually sorted, if we passed the position, the current line is likely the previous one
+                newIndex = if (i > 0) i - 1 else 0
+                break
+            }
+        }
+
+        // If we didn't break, we might be past the last line
+        if (newIndex == -1 && lines.isNotEmpty() && position >= lines.last().begin) {
+            newIndex = lines.size - 1
+        }
+
+        if (newIndex != -1 && newIndex != currentSuperLyricIndex) {
+            currentSuperLyricIndex = newIndex
+            val richLine = lines[newIndex]
+
+            val superLyricWords = richLine.words?.map { w ->
+                SuperLyricWord(w.text ?: "", w.begin, w.end)
+            }?.toTypedArray()
+
+            val mainLine = SuperLyricLine(
+                richLine.text ?: "",
+                superLyricWords,
+                richLine.begin,
+                richLine.end
+            )
+
+            val data = SuperLyricData()
+                .setTitle(currentSuperLyricTitle)
+                .setArtist(currentSuperLyricArtist)
+                .setAlbum(currentSuperLyricAlbum)
+                .setLyric(mainLine)
+
+            if (!richLine.secondary.isNullOrEmpty()) {
+                data.secondary = SuperLyricLine(richLine.secondary!!, richLine.begin, richLine.end)
+            }
+
+            if (!richLine.translation.isNullOrEmpty()) {
+                data.translation = SuperLyricLine(richLine.translation!!, richLine.begin, richLine.end)
+            }
+
+            SuperLyricHelper.sendLyric(data)
         }
     }
 
@@ -751,6 +825,13 @@ class MusicService : MediaSessionService() {
         val metadata = mediaItem.mediaMetadata
         val title = metadata.title?.toString() ?: "Unknown"
         val artist = metadata.artist?.toString() ?: "Unknown"
+        val album = metadata.albumTitle?.toString() ?: ""
+
+        currentSuperLyricTitle = title
+        currentSuperLyricArtist = artist
+        currentSuperLyricAlbum = album
+        currentSuperLyricLines = null
+        currentSuperLyricIndex = -1
 
         // 先设置歌曲基本信息
         lyriconProvider?.player?.setPlaybackState(activePlayer?.isPlaying ?: false)
@@ -764,6 +845,9 @@ class MusicService : MediaSessionService() {
         lyricJob = serviceScope.launch {
             cp.player.lyrics.LyricsManager.state.collect { state ->
                 if (state is cp.player.lyrics.LyricsState.Success && state.songId == songId) {
+                    currentSuperLyricLines = state.richLyricLines
+                    currentSuperLyricIndex = -1 // Force resync
+
                     lyriconProvider?.player?.setSong(
                         Song(
                             id = songId,
@@ -837,6 +921,7 @@ class MusicService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        SuperLyricHelper.unregisterPublisher()
         serviceScope.cancel()
         UserPreferences.getPrefs(this).unregisterOnSharedPreferenceChangeListener(enginePrefListener)
         crossfadeManager.release()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-window = "1.3.0"
 material-color-utilities = "2.0.0"
 
 [libraries]
+superlyricapi = { module = "com.github.HChenX:SuperLyricApi", version = "3.4" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "CP Player"


### PR DESCRIPTION
This PR adds `SuperLyricApi` (v3.4) to broadcast real-time lyrics data to external modules.

Changes included:
1. Added JitPack repository to `settings.gradle` and `SuperLyricApi` dependency to `app/build.gradle`.
2. Initialized publisher registration on `MusicService.onCreate()` and handled unregistration in `onDestroy()`.
3. Created a `syncSuperLyric` function alongside `syncToLyricon` to calculate the exact current lyric line based on playback position and issue real-time line-by-line updates via `SuperLyricHelper.sendLyric(data)`.
4. Attached lyric initialization on song change in `updateLyriconSong` which resets the internal SuperLyric data trackers, and parses metadata such as title, artist, album, and rich translated lyrics.
5. Emitted a stop signal via `SuperLyricHelper.sendStop()` on `MusicService` when playback pauses to align with the framework's state model.

---
*PR created automatically by Jules for task [12171762078797365971](https://jules.google.com/task/12171762078797365971) started by @Aurora-Nasa-1*