### PR TITLE
Fix SuperLyricHelper IllegalStateException in MusicService

### DIFF
--- a/app/src/main/java/cp/player/service/MusicService.kt
+++ b/app/src/main/java/cp/player/service/MusicService.kt
@@ -290,8 +290,10 @@ class MusicService : MediaSessionService() {
         super.onCreate()
         DebugLog.i("MusicService: Service onCreate")
 
-        SuperLyricHelper.registerPublisher()
-        SuperLyricHelper.setSystemPlayStateListenerEnabled(false)
+        if (SuperLyricHelper.isAvailable()) {
+            SuperLyricHelper.registerPublisher()
+            SuperLyricHelper.setSystemPlayStateListenerEnabled(false)
+        }
 
         usbAudioManager = UsbAudioManager(this)
         usbAudioManager?.start()
@@ -328,7 +330,9 @@ class MusicService : MediaSessionService() {
                     updateWidget()
                     lyriconProvider?.player?.setPlaybackState(isPlaying)
                     if (!isPlaying) {
-                        SuperLyricHelper.sendStop(SuperLyricData())
+                        if (SuperLyricHelper.isAvailable()) {
+                            SuperLyricHelper.sendStop(SuperLyricData())
+                        }
                     }
                 }
 
@@ -555,7 +559,9 @@ class MusicService : MediaSessionService() {
                     updateWidget()
                     lyriconProvider?.player?.setPlaybackState(isPlaying)
                     if (!isPlaying) {
-                        SuperLyricHelper.sendStop(SuperLyricData())
+                        if (SuperLyricHelper.isAvailable()) {
+                            SuperLyricHelper.sendStop(SuperLyricData())
+                        }
                     }
                 }
                 override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -734,7 +740,9 @@ class MusicService : MediaSessionService() {
                 data.translation = SuperLyricLine(richLine.translation!!, richLine.begin, richLine.end)
             }
 
-            SuperLyricHelper.sendLyric(data)
+            if (SuperLyricHelper.isAvailable()) {
+                SuperLyricHelper.sendLyric(data)
+            }
         }
     }
 
@@ -954,7 +962,9 @@ class MusicService : MediaSessionService() {
     override fun onDestroy() {
         // 保存当前播放队列以便下次恢复
         saveQueueOnExit()
-        SuperLyricHelper.unregisterPublisher()
+        if (SuperLyricHelper.isAvailable()) {
+            SuperLyricHelper.unregisterPublisher()
+        }
         serviceScope.cancel()
         UserPreferences.getPrefs(this).unregisterOnSharedPreferenceChangeListener(enginePrefListener)
         crossfadeManager.release()


### PR DESCRIPTION
Fixes a crash reported in Sentry where `MusicService` fails to start due to an `IllegalStateException` thrown by `SuperLyricHelper`.

**Root Cause:**
`SuperLyricHelper.registerPublisher()` and other methods internally call `ensureManager()`. If the system service `super_lyric` is not registered (which is the case if the SuperLyric Xposed module is not installed on the user's device), `ensureManager()` throws an `IllegalStateException: SuperLyricManager not attached.`.

**Solution:**
Guarded all calls to `SuperLyricHelper` (in `MusicService`) with `if (SuperLyricHelper.isAvailable())`, as per the official `SuperLyricApi` documentation. This prevents the exception from taking down `MusicService` and the application, gracefully degrading functionality instead.

---
*PR created automatically by Jules for task [1830522009191735371](https://jules.google.com/task/1830522009191735371) started by @Aurora-Nasa-1*