### PR TITLE
perf: hoist Regex compilation to avoid redundant allocations

### DIFF
--- a/app/src/main/java/cp/player/manager/LocalMusicManager.kt
+++ b/app/src/main/java/cp/player/manager/LocalMusicManager.kt
@@ -33,6 +33,8 @@ object LocalMusicManager {
     private val _bindingsFlow = MutableStateFlow<Map<String, CloudBinding>>(emptyMap())
     val bindingsFlow = _bindingsFlow.asStateFlow()
 
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
     /**
      * 云端歌曲绑定信息。
      */
@@ -237,7 +239,7 @@ object LocalMusicManager {
     }
 
     /** 字符串归一化：去空格、转小写 */
-    private fun normalize(s: String): String = s.trim().lowercase().replace(Regex("\\s+"), " ")
+    private fun normalize(s: String): String = s.trim().lowercase().replace(WHITESPACE_REGEX, " ")
 
     /** 简单相似度：基于公共子串比例 */
     private fun similarity(a: String, b: String): Float {

--- a/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
+++ b/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
@@ -21,6 +21,10 @@ import java.io.File
 
 class MediaMetadataUseCase(private val application: Application) {
 
+    companion object {
+        private val LOCAL_SONG_ID_REGEX = Regex("\\[(\\d+)\\]\\.(mp3|flac)$")
+    }
+
     suspend fun extractColorFromUrl(url: String?): Int? = withContext(Dispatchers.IO) {
         if (url.isNullOrEmpty()) return@withContext null
         try {
@@ -62,11 +66,10 @@ class MediaMetadataUseCase(private val application: Application) {
     suspend fun refreshLocalSongs() = withContext(Dispatchers.IO) {
         val musicDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC)
         val cpMusicDir = File(musicDir, "CPPlayer")
-        val idRegex = Regex("\\[(\\d+)\\]\\.(mp3|flac)$")
 
         if (cpMusicDir.exists()) {
             cpMusicDir.listFiles { _, name -> name.endsWith(".mp3") || name.endsWith(".flac") }?.forEach { file ->
-                val match = idRegex.find(file.name)
+                val match = LOCAL_SONG_ID_REGEX.find(file.name)
                 val songId = match?.groupValues?.get(1)
 
                 if (songId != null) {

--- a/app/src/main/java/cp/player/util/EmbeddedLyricsExtractor.kt
+++ b/app/src/main/java/cp/player/util/EmbeddedLyricsExtractor.kt
@@ -16,6 +16,7 @@ import java.io.File
  */
 object EmbeddedLyricsExtractor {
     private const val TAG = "EmbeddedLyricsExtractor"
+    private val LRC_REGEX = Regex("\\[\\d{2}:\\d{2}[.:]\\d{2,3}]")
 
     /**
      * 从本地音频文件提取内嵌歌词。
@@ -125,7 +126,7 @@ object EmbeddedLyricsExtractor {
      */
     private fun looksLikeLyrics(text: String): Boolean {
         // LRC 格式检测
-        if (text.contains(Regex("\\[\\d{2}:\\d{2}[.:]\\d{2,3}]"))) return true
+        if (text.contains(LRC_REGEX)) return true
         // 多行文本（至少 3 行，每行不太长）
         val lines = text.lines().filter { it.trim().isNotEmpty() }
         if (lines.size >= 3 && lines.all { it.length < 200 }) return true


### PR DESCRIPTION
- Extracted inline Regex instantiation in `EmbeddedLyricsExtractor.looksLikeLyrics` to a private constant.
- Extracted inline Regex in `LocalMusicManager.normalize` to a private constant.
- Extracted `idRegex` in `MediaMetadataUseCase.refreshLocalSongs` to a companion object constant.

These changes prevent the Regular Expressions from being recompiled on every function call or loop iteration, reducing unnecessary object allocations and improving performance.

---
*PR created automatically by Jules for task [1917608265353324670](https://jules.google.com/task/1917608265353324670) started by @Aurora-Nasa-1*