### PR TITLE
Fix backend provider startup port collision and enable reactive UI updates

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -304,10 +304,12 @@ fun AppMainContent(
             ) {
                 // 横屏时不再显示 NavigationRail，改为在 mini 播放器右侧显示导航胶囊
 
+                val availableProviders by cp.player.provider.ModuleManager.providersFlow.collectAsState()
+
                 Box(modifier = Modifier.weight(1f).fillMaxHeight().padding(top = 0.dp)) {
                     NavHost(
                         navController = navController,
-                        startDestination = if (cp.player.provider.ModuleManager.getAvailableProviders().isEmpty()) "setup" else "main",
+                        startDestination = if (availableProviders.isEmpty()) "setup" else "main",
                         modifier = Modifier.fillMaxSize(),
                         enterTransition = {
                             slideIntoContainer(

--- a/app/src/main/java/cp/player/provider/ModuleManager.kt
+++ b/app/src/main/java/cp/player/provider/ModuleManager.kt
@@ -3,6 +3,9 @@ package cp.player.provider
 import android.content.Context
 import android.util.Log
 import com.google.gson.Gson
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
 import java.io.FileOutputStream
 import java.util.zip.ZipInputStream
@@ -11,6 +14,14 @@ object ModuleManager {
     private const val TAG = "ModuleManager"
     private val gson = Gson()
     private val providers = mutableMapOf<String, BackendProvider>()
+
+    private val _providersFlow = MutableStateFlow<List<BackendProvider>>(emptyList())
+    /** 响应式的可用 Provider 列表流，供 UI 监听刷新 */
+    val providersFlow: StateFlow<List<BackendProvider>> = _providersFlow.asStateFlow()
+
+    private fun updateProvidersFlow() {
+        _providersFlow.value = providers.values.toList()
+    }
 
     /** 最近一次导入/加载失败的错误信息（供 UI 展示） */
     var lastLoadError: String? = null
@@ -29,9 +40,13 @@ object ModuleManager {
             }
         }
 
-        // 尝试恢复上次用户选择的 Provider（优先于自动选择的第一个）
-        if (ProviderManager.currentProvider != null) {
-            ProviderManager.restoreLastProvider(context)
+        updateProvidersFlow()
+
+        // 尝试恢复上次用户选择的 Provider
+        val restored = ProviderManager.restoreLastProvider(context)
+        // 如果没有成功恢复（例如第一次启动或上次的模块被删了），且当前有模块可用，则自动切换到第一个
+        if (!restored && providers.isNotEmpty() && ProviderManager.currentProvider == null) {
+            ProviderManager.switchProvider(providers.values.first(), appContext, save = false)
         }
     }
 
@@ -84,6 +99,8 @@ object ModuleManager {
             if (!success) {
                 // 加载失败时清理已移动的目录，避免残留损坏模块
                 targetDir.deleteRecursively()
+            } else {
+                updateProvidersFlow()
             }
             return success
         } catch (e: SecurityException) {
@@ -131,11 +148,6 @@ object ModuleManager {
             providers[manifest.id] = provider
             Log.i(TAG, "Loaded module: ${manifest.name} (${manifest.id})")
 
-            // 如果没有活跃 Provider，临时选择第一个加载的模块（不保存偏好，由 restoreLastProvider 决定最终选择）
-            if (ProviderManager.currentProvider == null) {
-                ProviderManager.switchProvider(provider, appContext, save = false)
-            }
-
             return true
         } catch (e: Exception) {
             lastLoadError = "加载失败: ${e.message}"
@@ -167,6 +179,7 @@ object ModuleManager {
         return try {
             dir.deleteRecursively()
             providers.remove(id)
+            updateProvidersFlow()
             Log.i(TAG, "Deleted module: $id")
             true
         } catch (e: Exception) {
@@ -250,7 +263,11 @@ object ModuleManager {
             if (oldDir.exists()) oldDir.deleteRecursively()
             tempDir.renameTo(oldDir)
 
-            return loadModule(oldDir)
+            val loaded = loadModule(oldDir)
+            if (loaded) {
+                updateProvidersFlow()
+            }
+            return loaded
         } catch (e: Exception) {
             Log.e(TAG, "Failed to update module: $id", e)
             return false

--- a/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
@@ -176,7 +176,7 @@ private fun HealthTabContent(currentTab: Int, scrollable: Boolean) {
 private fun HealthOverviewTab(scrollable: Boolean) {
     val records by HealthMonitor.recordsFlow.collectAsState()
     val allStats = remember(records) { HealthMonitor.getAllStats() }
-    val providers = remember { ModuleManager.getAvailableProviders() }
+    val providers by ModuleManager.providersFlow.collectAsState()
 
     val columnModifier = if (scrollable) {
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(horizontal = 16.dp, vertical = 12.dp)
@@ -909,7 +909,7 @@ private fun ApiMapTab(scrollable: Boolean) {
 
 @Composable
 private fun ProviderStatusTab(scrollable: Boolean) {
-    val providers = ModuleManager.getAvailableProviders()
+    val providers by ModuleManager.providersFlow.collectAsState()
     val currentProvider = ProviderManager.currentProvider
 
     val columnModifier = if (scrollable) {

--- a/app/src/main/java/cp/player/ui/screen/MainScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/MainScreen.kt
@@ -119,9 +119,11 @@ fun MainScreen(
     var showAccountDialog by remember { mutableStateOf(false) }
     var selectedSongForOptions by remember { mutableStateOf<Song?>(null) }
 
+    val availableProviders by cp.player.provider.ModuleManager.providersFlow.collectAsState()
+
     // 如果首次进入或者未登录状态，且有可用的 Provider，自动弹出登录框
     LaunchedEffect(Unit) {
-        if (!loginViewModel.isLogged && cp.player.provider.ModuleManager.getAvailableProviders().isNotEmpty()) {
+        if (!loginViewModel.isLogged && availableProviders.isNotEmpty()) {
             loginViewModel.refreshProviderState()
             showAccountDialog = true
         }

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -745,7 +745,7 @@ fun SettingsScreen(
                     }
                     SettingsPage.Provider -> {
                         SettingsSection(title = stringResource(R.string.provider_management)) {
-                            val providers = cp.player.provider.ModuleManager.getAvailableProviders()
+                            val providers by cp.player.provider.ModuleManager.providersFlow.collectAsState()
                             val coroutineScope = rememberCoroutineScope()
                             // 导入模块的 launcher
                             val importLauncher = rememberLauncherForActivityResult(
@@ -824,16 +824,12 @@ fun SettingsScreen(
 
                             // 提供者更多操作底部面板状态
                             var selectedProvider by remember { mutableStateOf<cp.player.provider.BackendProvider?>(null) }
-                            // 刷新列表用的计数器
-                            var refreshTrigger by remember { mutableIntStateOf(0) }
                             // 自动更新检查结果（provider id → UpdateInfo）
                             var updateResults by remember { mutableStateOf<Map<String, cp.player.provider.ProviderUpdateChecker.UpdateInfo>>(emptyMap()) }
 
                             val loginViewModel: LoginViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
-                            // 强制刷新时重新读取列表
-                            val currentProviders = remember(refreshTrigger) {
-                                cp.player.provider.ModuleManager.getAvailableProviders()
-                            }
+
+                            val currentProviders by cp.player.provider.ModuleManager.providersFlow.collectAsState()
 
                             // 进入 provider 页面时自动后台检查所有有 updateUrl 的模块更新
                             LaunchedEffect(currentProviders) {
@@ -947,12 +943,10 @@ fun SettingsScreen(
                                     onDeleted = {
                                         selectedProvider = null
                                         updateResults = updateResults - provider.id
-                                        refreshTrigger++
                                     },
                                     onUpdated = {
                                         selectedProvider = null
                                         updateResults = updateResults - provider.id
-                                        refreshTrigger++
                                     },
                                     onUpdateZipSelected = {
                                         updatingProviderId = provider.id

--- a/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
@@ -44,7 +44,7 @@ fun SetupScreen(
     val coroutineScope = rememberCoroutineScope()
     var isImporting by remember { mutableStateOf(false) }
     var importedSuccessfully by remember { mutableStateOf(false) }
-    var availableProviders by remember { mutableStateOf(ModuleManager.getAvailableProviders()) }
+    val availableProviders by ModuleManager.providersFlow.collectAsState()
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
@@ -67,7 +67,6 @@ fun SetupScreen(
                 }
                 isImporting = false
                 if (success) {
-                    availableProviders = ModuleManager.getAvailableProviders()
                     importedSuccessfully = true
                     Toast.makeText(context, context.getString(R.string.module_import_success), Toast.LENGTH_SHORT).show()
                 } else {

--- a/app/src/main/java/cp/player/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/LoginViewModel.kt
@@ -65,7 +65,7 @@ class LoginViewModel(application: Application) : BaseViewModel(application) {
         private set
 
     /** 所有已加载的 Provider 列表 */
-    var availableProviders by mutableStateOf(ModuleManager.getAvailableProviders())
+    var availableProviders by mutableStateOf<List<BackendProvider>>(emptyList())
         private set
 
     private var checkJob: Job? = null
@@ -86,6 +86,12 @@ class LoginViewModel(application: Application) : BaseViewModel(application) {
         refreshProviderState()
         // 尝试恢复被进程回收前的 QR 会话
         restoreQrSession()
+
+        viewModelScope.launch {
+            ModuleManager.providersFlow.collect { providers ->
+                availableProviders = providers
+            }
+        }
     }
 
     // ======================== Provider 管理 ========================
@@ -125,7 +131,6 @@ class LoginViewModel(application: Application) : BaseViewModel(application) {
         currentProviderName = ProviderManager.getCurrentProviderName()
         currentProviderId = ProviderManager.getCurrentProviderId()
         currentProviderVersion = ProviderManager.currentProvider?.version ?: ""
-        availableProviders = ModuleManager.getAvailableProviders()
     }
 
     // ======================== 扫码登录 ========================


### PR DESCRIPTION
解决了多音源提供者机制下的两个严重问题。
首先是**启动切换问题**，此前 `ModuleManager.init` 会在遍历并加载第一个模块时就立刻执行 `switchProvider`（尝试启动服务），在全部模块加载完后再切换到用户原本选择的 provider。这一行为会导致如 BinaryProvider/JNI 模块刚拉起绑定端口（如 3000），紧接着又被要求停止，引发端口占用导致真实选中的提供程序启动失败（或只能调用到之前的 provider 端点）。修复方式为取消在循环内的首个自动切换，待全部加载结束后，一次性执行 `restoreLastProvider` 或首选保底策略。

其次是**界面刷新问题**，此前 `SettingsScreen` 和其它页面对可用提供商列表获取是静态的（伴随部分硬编码和缺失的 `refreshTrigger` 累加）。这就导致用户导入、更新、甚至删除 provider 后，除非应用重启，否则界面列表不更新。修复方案为在 `ModuleManager` 中引入 `StateFlow`，并在所有的关联界面（如 `LoginViewModel`，各 Compose 页面）采用响应式流观察列表，彻底解决各种由于动态变更导致的 UI 刷新失效。

---
*PR created automatically by Jules for task [14066414915454349028](https://jules.google.com/task/14066414915454349028) started by @Aurora-Nasa-1*