### PR TITLE
Refactor version comparison logic into VersionUtils

### DIFF
--- a/app/src/main/java/cp/player/provider/ProviderUpdateChecker.kt
+++ b/app/src/main/java/cp/player/provider/ProviderUpdateChecker.kt
@@ -3,6 +3,7 @@ package cp.player.provider
 import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import cp.player.util.VersionUtils
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.util.concurrent.TimeUnit
@@ -71,7 +72,7 @@ object ProviderUpdateChecker {
                     Log.w(TAG, "Invalid update info: missing version or downloadUrl")
                     return null
                 }
-                if (compareVersions(localVersion, info.version) < 0) {
+                if (VersionUtils.compareVersions(localVersion, info.version) < 0) {
                     Log.i(TAG, "Update available: $localVersion → ${info.version}")
                     info
                 } else {
@@ -85,64 +86,4 @@ object ProviderUpdateChecker {
         }
     }
 
-    /**
-     * 比较两个语义化版本号（支持 pre-release 后缀，如 `1.0.0-beta3`）。
-     *
-     * 规则：
-     * 1. 先去掉 `v` 前缀，再按 `.` 分段比较数字部分
-     * 2. 数字部分相同时，有 pre-release 后缀的版本 **小于** 没有后缀的（如 `1.0.0-beta1` < `1.0.0`）
-     * 3. 都有后缀时，提取共同前缀字母后的数字部分比较（`beta2` < `beta3` < `beta123`）
-     *
-     * @return 负数 = v1 < v2，0 = 相等，正数 = v1 > v2
-     */
-    fun compareVersions(v1: String, v2: String): Int {
-        // 分离数字部分和 pre-release 后缀，同时去掉 v 前缀
-        fun parseVersion(version: String): Pair<List<Int>, String?> {
-            val v = version.removePrefix("v")
-            val dashIndex = v.indexOf('-')
-            val numericPart = if (dashIndex >= 0) v.substring(0, dashIndex) else v
-            val preRelease = if (dashIndex >= 0) v.substring(dashIndex + 1) else null
-            val parts = numericPart.split(".").map { it.toIntOrNull() ?: 0 }
-            return parts to preRelease
-        }
-
-        // 比较 pre-release 后缀，支持数字部分按数值比较（如 beta2 < beta123）
-        fun comparePreRelease(pre1: String, pre2: String): Int {
-            // 提取共同字母前缀后的数字部分
-            val regex = Regex("^([a-zA-Z]*)(\\d*)$")
-            val match1 = regex.matchEntire(pre1)
-            val match2 = regex.matchEntire(pre2)
-
-            if (match1 != null && match2 != null) {
-                val prefix1 = match1.groupValues[1]
-                val prefix2 = match2.groupValues[1]
-                // 先比较字母前缀
-                val prefixCmp = prefix1.compareTo(prefix2)
-                if (prefixCmp != 0) return prefixCmp
-                // 字母前缀相同，按数值比较数字部分
-                val num1 = match1.groupValues[2].toIntOrNull() ?: 0
-                val num2 = match2.groupValues[2].toIntOrNull() ?: 0
-                return num1 - num2
-            }
-            // 无法解析时回退到字符串比较
-            return pre1.compareTo(pre2)
-        }
-
-        val (parts1, pre1) = parseVersion(v1)
-        val (parts2, pre2) = parseVersion(v2)
-
-        val maxLen = maxOf(parts1.size, parts2.size)
-        for (i in 0 until maxLen) {
-            val p1 = parts1.getOrElse(i) { 0 }
-            val p2 = parts2.getOrElse(i) { 0 }
-            if (p1 != p2) return p1 - p2
-        }
-
-        return when {
-            pre1 != null && pre2 != null -> comparePreRelease(pre1, pre2)
-            pre1 != null && pre2 == null -> -1
-            pre1 == null && pre2 != null -> 1
-            else -> 0
-        }
-    }
 }

--- a/app/src/main/java/cp/player/update/AppUpdateChecker.kt
+++ b/app/src/main/java/cp/player/update/AppUpdateChecker.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import cp.player.BuildConfig
+import cp.player.util.VersionUtils
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.util.concurrent.TimeUnit
@@ -99,7 +100,7 @@ object AppUpdateChecker {
                 val remoteVersionName = latest.tagName.removePrefix("v")
 
                 // 比较版本：优先用版本名比较（因为 versionCode 可能不连续）
-                if (compareVersions(BuildConfig.VERSION_NAME, remoteVersionName) >= 0) {
+                if (VersionUtils.compareVersions(BuildConfig.VERSION_NAME, remoteVersionName) >= 0) {
                     Log.d(TAG, "Already up to date: ${BuildConfig.VERSION_NAME}")
                     return null
                 }
@@ -110,7 +111,7 @@ object AppUpdateChecker {
                 for (release in releases) {
                     val ver = release.tagName.removePrefix("v")
                     // 只收集比当前版本新的 release
-                    if (compareVersions(ver, currentVersion) <= 0) break
+                    if (VersionUtils.compareVersions(ver, currentVersion) <= 0) break
                     if (!release.body.isNullOrBlank()) {
                         changelogBuilder.appendLine("### ${release.tagName}")
                         changelogBuilder.appendLine()
@@ -140,70 +141,6 @@ object AppUpdateChecker {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to check update", e)
             null
-        }
-    }
-
-    /**
-     * 比较两个语义化版本号（支持 pre-release 后缀，如 `1.0.0-beta3`）。
-     *
-     * 规则：
-     * 1. 先去掉 `v` 前缀，再按 `.` 分段比较数字部分
-     * 2. 数字部分相同时，有 pre-release 后缀的版本 **小于** 没有后缀的（如 `1.0.0-beta1` < `1.0.0`）
-     * 3. 都有后缀时，提取共同前缀字母后的数字部分比较（`beta2` < `beta3` < `beta123`）
-     *
-     * @return 负数 = v1 < v2，0 = 相等，正数 = v1 > v2
-     */
-    fun compareVersions(v1: String, v2: String): Int {
-        // 分离数字部分和 pre-release 后缀，同时去掉 v 前缀
-        fun parseVersion(version: String): Pair<List<Int>, String?> {
-            val v = version.removePrefix("v")
-            val dashIndex = v.indexOf('-')
-            val numericPart = if (dashIndex >= 0) v.substring(0, dashIndex) else v
-            val preRelease = if (dashIndex >= 0) v.substring(dashIndex + 1) else null
-            val parts = numericPart.split(".").map { it.toIntOrNull() ?: 0 }
-            return parts to preRelease
-        }
-
-        // 比较 pre-release 后缀，支持数字部分按数值比较（如 beta2 < beta123）
-        fun comparePreRelease(pre1: String, pre2: String): Int {
-            // 提取共同字母前缀后的数字部分
-            val regex = Regex("^([a-zA-Z]*)(\\d*)$")
-            val match1 = regex.matchEntire(pre1)
-            val match2 = regex.matchEntire(pre2)
-
-            if (match1 != null && match2 != null) {
-                val prefix1 = match1.groupValues[1]
-                val prefix2 = match2.groupValues[1]
-                // 先比较字母前缀
-                val prefixCmp = prefix1.compareTo(prefix2)
-                if (prefixCmp != 0) return prefixCmp
-                // 字母前缀相同，按数值比较数字部分
-                val num1 = match1.groupValues[2].toIntOrNull() ?: 0
-                val num2 = match2.groupValues[2].toIntOrNull() ?: 0
-                return num1 - num2
-            }
-            // 无法解析时回退到字符串比较
-            return pre1.compareTo(pre2)
-        }
-
-        val (parts1, pre1) = parseVersion(v1)
-        val (parts2, pre2) = parseVersion(v2)
-
-        // 比较数字部分
-        val maxLen = maxOf(parts1.size, parts2.size)
-        for (i in 0 until maxLen) {
-            val p1 = parts1.getOrElse(i) { 0 }
-            val p2 = parts2.getOrElse(i) { 0 }
-            if (p1 != p2) return p1 - p2
-        }
-
-        // 数字部分相同，比较 pre-release 后缀
-        // 有 pre-release < 无 pre-release（如 1.0.0-beta1 < 1.0.0）
-        return when {
-            pre1 != null && pre2 != null -> comparePreRelease(pre1, pre2)
-            pre1 != null && pre2 == null -> -1
-            pre1 == null && pre2 != null -> 1
-            else -> 0
         }
     }
 

--- a/app/src/main/java/cp/player/util/VersionUtils.kt
+++ b/app/src/main/java/cp/player/util/VersionUtils.kt
@@ -1,0 +1,68 @@
+package cp.player.util
+
+private val PRE_RELEASE_REGEX = Regex("^([a-zA-Z]*)(\\d*)$")
+
+object VersionUtils {
+    /**
+     * 比较两个语义化版本号（支持 pre-release 后缀，如 `1.0.0-beta3`）。
+     *
+     * 规则：
+     * 1. 先去掉 `v` 前缀，再按 `.` 分段比较数字部分
+     * 2. 数字部分相同时，有 pre-release 后缀的版本 **小于** 没有后缀的（如 `1.0.0-beta1` < `1.0.0`）
+     * 3. 都有后缀时，提取共同前缀字母后的数字部分比较（`beta2` < `beta3` < `beta123`）
+     *
+     * @return 负数 = v1 < v2，0 = 相等，正数 = v1 > v2
+     */
+    fun compareVersions(v1: String, v2: String): Int {
+        // 分离数字部分和 pre-release 后缀，同时去掉 v 前缀
+        fun parseVersion(version: String): Pair<List<Int>, String?> {
+            val v = version.removePrefix("v")
+            val dashIndex = v.indexOf('-')
+            val numericPart = if (dashIndex >= 0) v.substring(0, dashIndex) else v
+            val preRelease = if (dashIndex >= 0) v.substring(dashIndex + 1) else null
+            val parts = numericPart.split(".").map { it.toIntOrNull() ?: 0 }
+            return parts to preRelease
+        }
+
+        // 比较 pre-release 后缀，支持数字部分按数值比较（如 beta2 < beta123）
+        fun comparePreRelease(pre1: String, pre2: String): Int {
+            // 提取共同字母前缀后的数字部分
+            val match1 = PRE_RELEASE_REGEX.matchEntire(pre1)
+            val match2 = PRE_RELEASE_REGEX.matchEntire(pre2)
+
+            if (match1 != null && match2 != null) {
+                val prefix1 = match1.groupValues[1]
+                val prefix2 = match2.groupValues[1]
+                // 先比较字母前缀
+                val prefixCmp = prefix1.compareTo(prefix2)
+                if (prefixCmp != 0) return prefixCmp
+                // 字母前缀相同，按数值比较数字部分
+                val num1 = match1.groupValues[2].toIntOrNull() ?: 0
+                val num2 = match2.groupValues[2].toIntOrNull() ?: 0
+                return num1 - num2
+            }
+            // 无法解析时回退到字符串比较
+            return pre1.compareTo(pre2)
+        }
+
+        val (parts1, pre1) = parseVersion(v1)
+        val (parts2, pre2) = parseVersion(v2)
+
+        // 比较数字部分
+        val maxLen = maxOf(parts1.size, parts2.size)
+        for (i in 0 until maxLen) {
+            val p1 = parts1.getOrElse(i) { 0 }
+            val p2 = parts2.getOrElse(i) { 0 }
+            if (p1 != p2) return p1 - p2
+        }
+
+        // 数字部分相同，比较 pre-release 后缀
+        // 有 pre-release < 无 pre-release（如 1.0.0-beta1 < 1.0.0）
+        return when {
+            pre1 != null && pre2 != null -> comparePreRelease(pre1, pre2)
+            pre1 != null && pre2 == null -> -1
+            pre1 == null && pre2 != null -> 1
+            else -> 0
+        }
+    }
+}


### PR DESCRIPTION
This change addresses the code duplication found in the update checkers by moving the version comparison utility into a centralized location `cp.player.util.VersionUtils`. Furthermore, it optimizes the regex processing within the comparison logic.

---
*PR created automatically by Jules for task [16780360554416710672](https://jules.google.com/task/16780360554416710672) started by @Aurora-Nasa-1*