### PR TITLE
Refactor URL extraction in MusicApiServiceImpl to use JsonUtils

### DIFF
--- a/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
+++ b/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
@@ -653,29 +653,6 @@ class MusicApiServiceImpl(
         // 优先从 redirectUrl 字段获取
         body.get("redirectUrl")?.asString?.let { if (it.startsWith("http")) return it }
         // 递归查找 URL
-        return findUrlRecursive(body)
-    }
-
-    private fun findUrlRecursive(element: com.google.gson.JsonElement?): String? {
-        if (element == null || element.isJsonNull) return null
-        if (element.isJsonPrimitive && element.asJsonPrimitive.isString) {
-            val s = element.asString
-            if (s.startsWith("http") && s.length > 12 && !s.contains("null")) return s
-        }
-        if (element.isJsonObject) {
-            val obj = element.asJsonObject
-            // 优先检查常见字段名
-            listOf("url", "picUrl", "coverImgUrl", "avatarUrl").firstNotNullOfOrNull { key ->
-                obj.get(key)?.takeIf { it.isJsonPrimitive }?.asString?.takeIf {
-                    it.startsWith("http") && it.length > 12 && !it.contains("null")
-                }
-            }?.let { return it }
-
-            return obj.entrySet().firstNotNullOfOrNull { findUrlRecursive(it.value) }
-        }
-        if (element.isJsonArray) {
-            return element.asJsonArray.firstNotNullOfOrNull { findUrlRecursive(it) }
-        }
-        return null
+        return cp.player.util.JsonUtils.findUrl(body)
     }
 }


### PR DESCRIPTION
This PR removes redundant JSON URL recursive scanning logic from `MusicApiServiceImpl.kt` by directly utilizing the centralized `JsonUtils.findUrl(body)` utility.

**Benefits:**
*   **Conciseness:** Removes duplicated boilerplate.
*   **Performance:** The original recursive function allocated a new `listOf("url", "picUrl", "coverImgUrl", "avatarUrl")` list on every recursive call, whereas `JsonUtils.findUrl` uses an optimized approach with a static `PRIORITY_KEYS` constant, avoiding unnecessary intermediate allocations.
*   **Maintainability:** Centralizes JSON object URL resolution in a single location (`JsonUtils`).

Tested via `./gradlew test` successfully.

---
*PR created automatically by Jules for task [10231616382122689054](https://jules.google.com/task/10231616382122689054) started by @Aurora-Nasa-1*