### PR TITLE
Fix ANR caused by Gson().toJson() blocking the main thread

### DIFF
--- a/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
@@ -162,14 +162,20 @@ class PlaybackViewModel(application: Application) : BaseViewModel(application) {
         if (!UserPreferences.getRestoreLastQueue(context)) return
         val queue = currentQueue
         if (queue.isEmpty()) return
-        try {
-            val json = Gson().toJson(queue)
-            val index = mediaController?.currentMediaItemIndex ?: 0
-            val position = currentPosition
-            UserPreferences.saveLastQueue(context, json, index, position, isPlaying)
-            DebugLog.i("PlaybackVM: Saved queue: ${queue.size} songs, index=$index, pos=$position, playing=$isPlaying")
-        } catch (e: Exception) {
-            DebugLog.e("PlaybackVM: Failed to save queue: ${e.message}")
+
+        val queueSnapshot = queue.toList()
+        val index = mediaController?.currentMediaItemIndex ?: 0
+        val position = currentPosition
+        val playing = isPlaying
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val json = Gson().toJson(queueSnapshot)
+                UserPreferences.saveLastQueue(context, json, index, position, playing)
+                DebugLog.i("PlaybackVM: Saved queue: ${queueSnapshot.size} songs, index=$index, pos=$position, playing=$playing")
+            } catch (e: Exception) {
+                DebugLog.e("PlaybackVM: Failed to save queue: ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -163,12 +163,14 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                         subscribedPlaylists = userPlaylists.filter { it.subscribed }.map { it.id }.toSet()
 
                         // 缓存歌单数据
-                        CacheManager.save(
-                            getApplication(),
-                            CacheManager.CacheType.USER_PLAYLISTS,
-                            "",
-                            Gson().toJson(userPlaylists)
-                        )
+                        withContext(Dispatchers.IO) {
+                            CacheManager.save(
+                                getApplication(),
+                                CacheManager.CacheType.USER_PLAYLISTS,
+                                "",
+                                Gson().toJson(userPlaylists)
+                            )
+                        }
 
                         val favBody = withContext(Dispatchers.IO) { api.getLikeList(resolvedUid) }
                         favoriteSongs = favBody.get("ids")?.takeIf { it.isJsonArray }?.asJsonArray?.map { it.asString } ?: emptyList()
@@ -356,12 +358,14 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
 
                     // 缓存歌单元数据和歌曲（仅首次加载且有数据时）
                     if (!isLoadMore && playlistSongs.isNotEmpty()) {
-                        CacheManager.save(
-                            getApplication(),
-                            CacheManager.CacheType.PLAYLIST_DETAIL,
-                            playlistId.toString(),
-                            playlistCacheToJson(currentPlaylistMetadata, playlistSongs)
-                        )
+                        withContext(Dispatchers.IO) {
+                            CacheManager.save(
+                                getApplication(),
+                                CacheManager.CacheType.PLAYLIST_DETAIL,
+                                playlistId.toString(),
+                                playlistCacheToJson(currentPlaylistMetadata, playlistSongs)
+                            )
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -439,12 +443,14 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                             }
                         }
                         // 始终更新缓存（包含作曲家和总时长）
-                        CacheManager.save(
-                            getApplication(),
-                            CacheManager.CacheType.PLAYLIST_DETAIL,
-                            playlistId.toString(),
-                            playlistCacheToJson(newMetadata ?: currentPlaylistMetadata, allSongs)
-                        )
+                        withContext(Dispatchers.IO) {
+                            CacheManager.save(
+                                getApplication(),
+                                CacheManager.CacheType.PLAYLIST_DETAIL,
+                                playlistId.toString(),
+                                playlistCacheToJson(newMetadata ?: currentPlaylistMetadata, allSongs)
+                            )
+                        }
                     }
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
Fixes the ANR crashes reported in Sentry (e.g. ANDROID-10). These crashes were caused by synchronous `Gson().toJson()` calls attempting to serialize potentially large queue arrays directly on the main UI thread.

The fix moves these operations to the IO dispatcher while correctly isolating and copying mutable state (like the playback queue) on the main thread before context-switching to avoid thread confinement issues or `ConcurrentModificationException`s.

---
*PR created automatically by Jules for task [18059401016454909503](https://jules.google.com/task/18059401016454909503) started by @Aurora-Nasa-1*