### PR TITLE
Fix redundant Elvis operator warning in HealthScreen.kt

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
@@ -653,7 +653,7 @@ private fun CallRecordRow(record: HealthMonitor.ApiCallRecord, compact: Boolean)
                                     Column {
                                         Text(formatWarning(w), style = MaterialTheme.typography.bodySmall, color = Color(0xFFFF9800))
                                         if (w == HealthMonitor.ResponseWarning.MISSING_DATA_FIELD && record.expectedField != null) {
-                                            Text("  " + stringResource(R.string.expected_field, record.expectedField ?: ""), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, color = Color(0xFFFF9800).copy(alpha = 0.7f))
+                                            Text("  " + stringResource(R.string.expected_field, record.expectedField), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, color = Color(0xFFFF9800).copy(alpha = 0.7f))
                                         }
                                     }
                                 }


### PR DESCRIPTION
Removed a redundant Elvis operator `?: ""` in `HealthScreen.kt` when formatting `record.expectedField`. The variable is already checked for nullability (`record.expectedField != null`) in the enclosing `if` block, making the fallback string unnecessary and causing a compiler warning.

---
*PR created automatically by Jules for task [8745574356232476830](https://jules.google.com/task/8745574356232476830) started by @Aurora-Nasa-1*