### PR TITLE
Fix ANR caused by Gson serialization on the main thread

### DIFF
--- a/app/src/main/java/cp/player/service/MusicService.kt
+++ b/app/src/main/java/cp/player/service/MusicService.kt
@@ -963,11 +963,18 @@ class MusicService : MediaSessionService() {
                     albumArtUrl = meta.artworkUri?.toString()
                 )
             }
-            val json = com.google.gson.Gson().toJson(songs)
             val index = player.currentMediaItemIndex
             val position = player.currentPosition
-            UserPreferences.saveLastQueue(this, json, index, position)
-            DebugLog.i("MusicService: Saved queue on exit: ${songs.size} songs, index=$index, pos=$position")
+
+            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+                try {
+                    val json = com.google.gson.Gson().toJson(songs)
+                    UserPreferences.saveLastQueue(this@MusicService, json, index, position)
+                    DebugLog.i("MusicService: Saved queue on exit: ${songs.size} songs, index=$index, pos=$position")
+                } catch (e: Exception) {
+                    DebugLog.e("MusicService: Failed to serialize and save queue on exit: ${e.message}")
+                }
+            }
         } catch (e: Exception) {
             DebugLog.e("MusicService: Failed to save queue on exit: ${e.message}")
         }

--- a/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/PlaybackViewModel.kt
@@ -160,16 +160,21 @@ class PlaybackViewModel(application: Application) : BaseViewModel(application) {
     fun saveCurrentQueue() {
         val context = getApplication<Application>()
         if (!UserPreferences.getRestoreLastQueue(context)) return
-        val queue = currentQueue
+        val queue = currentQueue.toList()
         if (queue.isEmpty()) return
-        try {
-            val json = Gson().toJson(queue)
-            val index = mediaController?.currentMediaItemIndex ?: 0
-            val position = currentPosition
-            UserPreferences.saveLastQueue(context, json, index, position, isPlaying)
-            DebugLog.i("PlaybackVM: Saved queue: ${queue.size} songs, index=$index, pos=$position, playing=$isPlaying")
-        } catch (e: Exception) {
-            DebugLog.e("PlaybackVM: Failed to save queue: ${e.message}")
+
+        val index = mediaController?.currentMediaItemIndex ?: 0
+        val position = currentPosition
+        val playing = isPlaying
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val json = Gson().toJson(queue)
+                UserPreferences.saveLastQueue(context, json, index, position, playing)
+                DebugLog.i("PlaybackVM: Saved queue: ${queue.size} songs, index=$index, pos=$position, playing=$playing")
+            } catch (e: Exception) {
+                DebugLog.e("PlaybackVM: Failed to save queue: ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -163,12 +163,14 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                         subscribedPlaylists = userPlaylists.filter { it.subscribed }.map { it.id }.toSet()
 
                         // 缓存歌单数据
-                        CacheManager.save(
-                            getApplication(),
-                            CacheManager.CacheType.USER_PLAYLISTS,
-                            "",
-                            Gson().toJson(userPlaylists)
-                        )
+                        withContext(Dispatchers.IO) {
+                            CacheManager.save(
+                                getApplication(),
+                                CacheManager.CacheType.USER_PLAYLISTS,
+                                "",
+                                Gson().toJson(userPlaylists)
+                            )
+                        }
 
                         val favBody = withContext(Dispatchers.IO) { api.getLikeList(resolvedUid) }
                         favoriteSongs = favBody.get("ids")?.takeIf { it.isJsonArray }?.asJsonArray?.map { it.asString } ?: emptyList()


### PR DESCRIPTION
Fixes a severe ANR reported by Sentry where `Gson().toJson` calls and subsequent SharedPreferences saves were blocking the main thread. The changes offload these operations to IO Coroutine dispatchers while correctly capturing the state on the main thread to prevent ConcurrentModificationException or similar thread confinement issues.

---
*PR created automatically by Jules for task [7382362016573450455](https://jules.google.com/task/7382362016573450455) started by @Aurora-Nasa-1*