### PR TITLE
Refactor JsonUtils safe extensions and simplify dependent code

### DIFF
--- a/app/src/main/java/cp/player/repository/PlaybackRepository.kt
+++ b/app/src/main/java/cp/player/repository/PlaybackRepository.kt
@@ -8,6 +8,8 @@ import cp.player.model.LyricLine
 import cp.player.model.Song
 import cp.player.service.LyricService
 import cp.player.util.JsonUtils
+import cp.player.util.arr
+import cp.player.util.obj
 
 /**
  * 播放数据仓库。
@@ -47,7 +49,7 @@ class PlaybackRepository(
      */
     suspend fun getPersonalFm(cookie: String?): List<Song> {
         val body = api.callApi(MusicApiMethod.PERSONAL_FM, mapOf("timestamp" to System.currentTimeMillis().toString()), cookie)
-        return (body.get("data")?.asJsonArray ?: body.get("result")?.asJsonArray)
+        return (body.get("data").arr ?: body.get("result").arr)
             ?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
     }
 
@@ -70,13 +72,10 @@ class PlaybackRepository(
             ),
             cookie
         )
-        val songsJson = when {
-            body.get("data")?.isJsonArray == true -> body.get("data").asJsonArray
-            body.get("data")?.isJsonObject == true && body.get("data").asJsonObject.has("data") ->
-                body.get("data").asJsonObject.get("data").asJsonArray
-            body.has("list") && body.get("list").isJsonArray -> body.get("list").asJsonArray
-            else -> null
-        }
+        val songsJson = body.get("data").arr
+            ?: body.get("data").obj?.get("data").arr
+            ?: body.get("list").arr
+
         return songsJson?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
     }
 }

--- a/app/src/main/java/cp/player/service/LyricService.kt
+++ b/app/src/main/java/cp/player/service/LyricService.kt
@@ -3,6 +3,8 @@ package cp.player.service
 import com.google.gson.JsonObject
 import cp.player.model.LyricLine
 import cp.player.util.LyricUtils
+import cp.player.util.obj
+import cp.player.util.str
 
 /**
  * 统一的歌词获取和解析服务。
@@ -21,9 +23,9 @@ object LyricService {
      * @return 已合并翻译的歌词行列表
      */
     fun parseFromJson(body: JsonObject, duration: Long): List<LyricLine> {
-        val lrc = body.get("lrc")?.asJsonObject?.get("lyric")?.asString ?: ""
-        val yrc = body.get("yrc")?.asJsonObject?.get("lyric")?.asString ?: ""
-        val tlyric = body.get("tlyric")?.asJsonObject?.get("lyric")?.asString ?: ""
+        val lrc = body.get("lrc").obj?.get("lyric").str ?: ""
+        val yrc = body.get("yrc").obj?.get("lyric").str ?: ""
+        val tlyric = body.get("tlyric").obj?.get("lyric").str ?: ""
         return parseLyrics(lrc, yrc, tlyric, duration)
     }
 

--- a/app/src/main/java/cp/player/util/JsonUtils.kt
+++ b/app/src/main/java/cp/player/util/JsonUtils.kt
@@ -10,12 +10,12 @@ import cp.player.model.Message
 import cp.player.model.Comment
 import cp.player.model.Playlist
 
-private val JsonElement?.obj: JsonObject? get() = if (this?.isJsonObject == true) this.asJsonObject else null
-private val JsonElement?.arr: JsonArray? get() = if (this?.isJsonArray == true) this.asJsonArray else null
-private val JsonElement?.str: String? get() = if (this?.isJsonPrimitive == true) this.asString else null
-private val JsonElement?.long: Long? get() = try { if (this?.isJsonPrimitive == true) this.asLong else null } catch (e: Exception) { null }
-private val JsonElement?.int: Int? get() = try { if (this?.isJsonPrimitive == true) this.asInt else null } catch (e: Exception) { null }
-private val JsonElement?.bool: Boolean? get() = try { if (this?.isJsonPrimitive == true) this.asBoolean else null } catch (e: Exception) { null }
+internal val JsonElement?.obj: JsonObject? get() = if (this?.isJsonObject == true) this.asJsonObject else null
+internal val JsonElement?.arr: JsonArray? get() = if (this?.isJsonArray == true) this.asJsonArray else null
+internal val JsonElement?.str: String? get() = if (this?.isJsonPrimitive == true) this.asString else null
+internal val JsonElement?.long: Long? get() = try { if (this?.isJsonPrimitive == true) this.asLong else null } catch (e: Exception) { null }
+internal val JsonElement?.int: Int? get() = try { if (this?.isJsonPrimitive == true) this.asInt else null } catch (e: Exception) { null }
+internal val JsonElement?.bool: Boolean? get() = try { if (this?.isJsonPrimitive == true) this.asBoolean else null } catch (e: Exception) { null }
 
 object JsonUtils {
     private val PRIORITY_KEYS = listOf("al", "album", "data", "result", "songs", "urlInfo")


### PR DESCRIPTION
This PR improves code conciseness and safety by utilizing existing safe JSON parsing extensions across multiple files.

1. **`JsonUtils.kt`**: Promoted the visibility of safe JSON extension properties (`obj`, `arr`, `str`, `long`, `int`, `bool`) from `private` to `internal`. This allows them to be used throughout the application to prevent `IllegalStateException` crashes from incorrect Gson type assumptions.
2. **`PlaybackRepository.kt`**: Refactored `getHeartbeatSongs` and `getPersonalFm` to use the internal `arr` and `obj` safe extensions. This drastically simplified complex `when` statements and unsafe `.asJsonObject` / `.asJsonArray` calls into elegant Elvis operator (`?:`) chains.
3. **`LyricService.kt`**: Refactored `parseFromJson` to use the `obj` and `str` safe extensions instead of the unsafe `.asJsonObject` and `.asString` calls, mirroring the conciseness gained in the repository layer.

---
*PR created automatically by Jules for task [1290977225527340387](https://jules.google.com/task/1290977225527340387) started by @Aurora-Nasa-1*