### PR TITLE
fix: ActivityNotFoundException on dirPicker.launch in SettingsScreen

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -730,7 +730,13 @@ fun SettingsScreen(
                             ExpressiveClickItem(
                                 title = stringResource(R.string.download_dir),
                                 subtitle = downloadDir?.substringAfterLast("%2F") ?: stringResource(R.string.system_music_folder),
-                                onClick = { dirPicker.launch(null) },
+                                onClick = {
+                                    try {
+                                        dirPicker.launch(null)
+                                    } catch (e: android.content.ActivityNotFoundException) {
+                                        android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager_found), android.widget.Toast.LENGTH_SHORT).show()
+                                    }
+                                },
                                 shapes = ListItemDefaults.segmentedShapes(4, 6)
                             )
                             

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -597,4 +597,5 @@
     <string name="new_songs_express">New Releases</string>
     <string name="quality_playlists">Featured Playlists</string>
     <string name="view_more">View More</string>
+    <string name="no_file_manager_found">No file manager found to open directory picker</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -603,4 +603,5 @@
     <string name="dsp_equalizer">DSP &amp; イコライザー</string>
     <string name="dsp_effects">DSP &amp; エフェクト</string>
     <string name="dsp_equalizer_desc">イコライザーと空間エフェクトを設定</string>
+    <string name="no_file_manager_found">ファイルマネージャーが見つかりません</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -586,4 +586,5 @@
     <string name="dsp_equalizer">DSP &amp; 均衡器</string>
     <string name="dsp_effects">DSP &amp; 音效</string>
     <string name="dsp_equalizer_desc">配置均衡器和空间音效</string>
+    <string name="no_file_manager_found">未找到文件管理器，无法打开目录选择器</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -600,4 +600,5 @@
     <string name="quality_playlists">精品歌单</string>
     <string name="view_more">查看更多</string>
 
+    <string name="no_file_manager_found">未找到文件管理器，无法打开目录选择器</string>
 </resources>


### PR DESCRIPTION
Fixes an `ActivityNotFoundException` crash reported by Sentry (issue `ANDROID-12`) that happens when trying to open the directory picker in `SettingsScreen`. The intent launcher `dirPicker.launch(null)` is now wrapped in a `try-catch` block, showing a localized Toast message when no suitable file manager is found on the device. Added the `no_file_manager_found` string resource across `values/strings.xml`, `values-en/strings.xml`, `values-zh/strings.xml`, and `values-ja/strings.xml`.

---
*PR created automatically by Jules for task [10241665216838854925](https://jules.google.com/task/10241665216838854925) started by @Aurora-Nasa-1*