### PR TITLE
Refactor raw Gson JSON casting to use safe extensions

### DIFF
--- a/app/src/main/java/cp/player/repository/PlaybackRepository.kt
+++ b/app/src/main/java/cp/player/repository/PlaybackRepository.kt
@@ -47,7 +47,7 @@ class PlaybackRepository(
      */
     suspend fun getPersonalFm(cookie: String?): List<Song> {
         val body = api.callApi(MusicApiMethod.PERSONAL_FM, mapOf("timestamp" to System.currentTimeMillis().toString()), cookie)
-        return (body.get("data")?.asJsonArray ?: body.get("result")?.asJsonArray)
+        return (cp.player.util.JsonUtils.findJsonArray(body, "data") ?: cp.player.util.JsonUtils.findJsonArray(body, "result"))
             ?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
     }
 
@@ -70,13 +70,7 @@ class PlaybackRepository(
             ),
             cookie
         )
-        val songsJson = when {
-            body.get("data")?.isJsonArray == true -> body.get("data").asJsonArray
-            body.get("data")?.isJsonObject == true && body.get("data").asJsonObject.has("data") ->
-                body.get("data").asJsonObject.get("data").asJsonArray
-            body.has("list") && body.get("list").isJsonArray -> body.get("list").asJsonArray
-            else -> null
-        }
+        val songsJson = cp.player.util.JsonUtils.findJsonArray(body, "data") ?: cp.player.util.JsonUtils.findJsonArray(body, "list")
         return songsJson?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
     }
 }

--- a/app/src/main/java/cp/player/service/LyricService.kt
+++ b/app/src/main/java/cp/player/service/LyricService.kt
@@ -3,6 +3,8 @@ package cp.player.service
 import com.google.gson.JsonObject
 import cp.player.model.LyricLine
 import cp.player.util.LyricUtils
+import cp.player.util.obj
+import cp.player.util.str
 
 /**
  * 统一的歌词获取和解析服务。
@@ -21,9 +23,9 @@ object LyricService {
      * @return 已合并翻译的歌词行列表
      */
     fun parseFromJson(body: JsonObject, duration: Long): List<LyricLine> {
-        val lrc = body.get("lrc")?.asJsonObject?.get("lyric")?.asString ?: ""
-        val yrc = body.get("yrc")?.asJsonObject?.get("lyric")?.asString ?: ""
-        val tlyric = body.get("tlyric")?.asJsonObject?.get("lyric")?.asString ?: ""
+        val lrc = body.get("lrc")?.obj?.get("lyric")?.str ?: ""
+        val yrc = body.get("yrc")?.obj?.get("lyric")?.str ?: ""
+        val tlyric = body.get("tlyric")?.obj?.get("lyric")?.str ?: ""
         return parseLyrics(lrc, yrc, tlyric, duration)
     }
 

--- a/app/src/main/java/cp/player/util/JsonUtils.kt
+++ b/app/src/main/java/cp/player/util/JsonUtils.kt
@@ -10,12 +10,12 @@ import cp.player.model.Message
 import cp.player.model.Comment
 import cp.player.model.Playlist
 
-private val JsonElement?.obj: JsonObject? get() = if (this?.isJsonObject == true) this.asJsonObject else null
-private val JsonElement?.arr: JsonArray? get() = if (this?.isJsonArray == true) this.asJsonArray else null
-private val JsonElement?.str: String? get() = if (this?.isJsonPrimitive == true) this.asString else null
-private val JsonElement?.long: Long? get() = try { if (this?.isJsonPrimitive == true) this.asLong else null } catch (e: Exception) { null }
-private val JsonElement?.int: Int? get() = try { if (this?.isJsonPrimitive == true) this.asInt else null } catch (e: Exception) { null }
-private val JsonElement?.bool: Boolean? get() = try { if (this?.isJsonPrimitive == true) this.asBoolean else null } catch (e: Exception) { null }
+internal val JsonElement?.obj: JsonObject? get() = if (this?.isJsonObject == true) this.asJsonObject else null
+internal val JsonElement?.arr: JsonArray? get() = if (this?.isJsonArray == true) this.asJsonArray else null
+internal val JsonElement?.str: String? get() = if (this?.isJsonPrimitive == true) this.asString else null
+internal val JsonElement?.long: Long? get() = try { if (this?.isJsonPrimitive == true) this.asLong else null } catch (e: Exception) { null }
+internal val JsonElement?.int: Int? get() = try { if (this?.isJsonPrimitive == true) this.asInt else null } catch (e: Exception) { null }
+internal val JsonElement?.bool: Boolean? get() = try { if (this?.isJsonPrimitive == true) this.asBoolean else null } catch (e: Exception) { null }
 
 object JsonUtils {
     private val PRIORITY_KEYS = listOf("al", "album", "data", "result", "songs", "urlInfo")


### PR DESCRIPTION
This refactoring addresses the user's request to specifically target a code block for simplification and structural optimization. 

I identified the repetitive and potentially unsafe usage of raw Gson JSON elements parsing (e.g., `.asJsonObject`, `.asJsonArray`, `.asString`) across several files. I modified `app/src/main/java/cp/player/util/JsonUtils.kt` to expose its safely validated extension properties by changing them from `private` to `internal`. Following this, I refactored `app/src/main/java/cp/player/repository/PlaybackRepository.kt` and `app/src/main/java/cp/player/service/LyricService.kt` to use these simplified extensions, which natively handle nulls and type checking gracefully, creating a much cleaner and safer JSON parsing structure. Test suite run confirmed no regressions.

---
*PR created automatically by Jules for task [4570579903641787138](https://jules.google.com/task/4570579903641787138) started by @Aurora-Nasa-1*