### PR TITLE
perf: Optimize SleepTimerBottomSheet recomposition overhead

### DIFF
--- a/app/src/main/java/cp/player/ui/component/SleepTimerBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/SleepTimerBottomSheet.kt
@@ -11,6 +11,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import java.text.DecimalFormatSymbols
+
+private val SLEEP_TIMER_OPTIONS = listOf(
+    "Off" to 0,
+    "10 Minutes" to 10,
+    "20 Minutes" to 20,
+    "30 Minutes" to 30,
+    "45 Minutes" to 45,
+    "60 Minutes" to 60,
+    "90 Minutes" to 90
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -19,16 +30,6 @@ fun SleepTimerBottomSheet(
     onSetTimer: (Int) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val options = listOf(
-        "Off" to 0,
-        "10 Minutes" to 10,
-        "20 Minutes" to 20,
-        "30 Minutes" to 30,
-        "45 Minutes" to 45,
-        "60 Minutes" to 60,
-        "90 Minutes" to 90
-    )
-
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState()
@@ -48,15 +49,24 @@ fun SleepTimerBottomSheet(
             if (remainingTime > 0) {
                 val minutes = (remainingTime / 1000) / 60
                 val seconds = (remainingTime / 1000) % 60
+                val locale = androidx.compose.ui.platform.LocalConfiguration.current.locales[0]
+                val zeroDigit = DecimalFormatSymbols.getInstance(locale).zeroDigit
+                val timeStr = if (zeroDigit == '0') {
+                    val mStr = if (minutes < 10) "0$minutes" else minutes.toString()
+                    val sStr = if (seconds < 10) "0$seconds" else seconds.toString()
+                    "$mStr:$sStr"
+                } else {
+                    String.format(locale, "%02d:%02d", minutes, seconds)
+                }
                 Text(
-                    text = "Remaining: ${String.format(androidx.compose.ui.platform.LocalConfiguration.current.locales[0], "%02d:%02d", minutes, seconds)}",
+                    text = "Remaining: $timeStr",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                 )
             }
 
-            options.forEach { (label, minutes) ->
+            SLEEP_TIMER_OPTIONS.forEach { (label, minutes) ->
                 cp.player.ui.component.UnifiedListItem(
     onClick = { onSetTimer(minutes)
                             onDismiss() },


### PR DESCRIPTION
- Hoisted static list in `SleepTimerBottomSheet` to avoid reallocation on recomposition.
- Replaced `String.format` with fast string templates to minimize parsing overhead on ticking timers.

---
*PR created automatically by Jules for task [12064381367911122679](https://jules.google.com/task/12064381367911122679) started by @Aurora-Nasa-1*