### PR TITLE
Fix ActivityNotFoundException on implicit intents

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.setValue
 import kotlin.math.log10
 import kotlin.math.pow
 import kotlin.math.roundToInt
+import cp.player.R
 
 private data class EqNode(val freq: Float, val gain: Float, val q: Float = 0f)
 
@@ -165,7 +166,7 @@ fun DspSettingsScreen(onNavigateBack: () -> Unit) {
                     )
                     Spacer(Modifier.weight(1f))
                     // 导入 AutoEQ
-                    IconButton(onClick = { launcher.launch("text/plain") }, modifier = Modifier.size(36.dp)) {
+                    IconButton(onClick = { try { launcher.launch("text/plain") } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() } }, modifier = Modifier.size(36.dp)) {
                         Icon(Icons.Outlined.FolderOpen, "导入", modifier = Modifier.size(20.dp))
                     }
                     // 重置

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -730,7 +730,7 @@ fun SettingsScreen(
                             ExpressiveClickItem(
                                 title = stringResource(R.string.download_dir),
                                 subtitle = downloadDir?.substringAfterLast("%2F") ?: stringResource(R.string.system_music_folder),
-                                onClick = { dirPicker.launch(null) },
+                                onClick = { try { dirPicker.launch(null) } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() } },
                                 shapes = ListItemDefaults.segmentedShapes(4, 6)
                             )
                             
@@ -929,7 +929,7 @@ fun SettingsScreen(
 
                             ExpressiveButtonItem(
                                 text = stringResource(R.string.import_new_module),
-                                onClick = { importLauncher.launch("application/zip") },
+                                onClick = { try { importLauncher.launch("application/zip") } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() } },
                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                 shapes = ListItemDefaults.segmentedShapes(currentProviders.size, currentProviders.size + 1)
@@ -950,7 +950,7 @@ fun SettingsScreen(
                                     },
                                     onUpdateZipSelected = {
                                         updatingProviderId = provider.id
-                                        updateLauncher.launch("application/zip")
+                                        try { updateLauncher.launch("application/zip") } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() }
                                     },
                                     onSettingsSelected = {
                                         currentProviderSettingsId = provider.id

--- a/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
@@ -209,7 +209,7 @@ fun SetupScreen(
                         Icon(Icons.Filled.ArrowForward, contentDescription = null)
                     }
                     OutlinedButton(
-                        onClick = { launcher.launch("application/zip") },
+                        onClick = { try { launcher.launch("application/zip") } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() } },
                         modifier = Modifier.fillMaxWidth().height(56.dp),
                         shape = MaterialTheme.shapes.extraLarge
                     ) {
@@ -220,7 +220,7 @@ fun SetupScreen(
                     }
                 } else {
                     Button(
-                        onClick = { launcher.launch("application/zip") },
+                        onClick = { try { launcher.launch("application/zip") } catch (e: android.content.ActivityNotFoundException) { android.widget.Toast.makeText(context, context.getString(R.string.no_file_manager), android.widget.Toast.LENGTH_SHORT).show() } },
                         modifier = Modifier.fillMaxWidth().height(64.dp),
                         shape = MaterialTheme.shapes.extraLarge
                     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,7 @@
     <string name="module_import_failed">模块导入失败</string>
     <string name="module_import_failed_detail">模块导入失败：%s</string>
     <string name="module_import_error">导入模块时出错</string>
+    <string name="no_file_manager">未找到文件管理器应用，请安装一个文件管理器。</string>
     <string name="provider_active">（当前活跃）</string>
     <string name="provider_info">类型: %1$s | 版本: %2$s</string>
     <string name="provider_switched">已切换到 %1$s</string>


### PR DESCRIPTION
- Caught `ActivityNotFoundException` when launching file picker intents in `SettingsScreen`, `SetupScreen`, and `DspSettingsScreen`.
- Added a `no_file_manager` string resource to show a helpful Toast when the exception occurs instead of crashing the app.

---
*PR created automatically by Jules for task [4229087200325847891](https://jules.google.com/task/4229087200325847891) started by @Aurora-Nasa-1*