### PR TITLE
Optimize findUrlRecursive to prevent redundant memory allocations

### DIFF
--- a/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
+++ b/app/src/main/java/cp/player/api/MusicApiServiceImpl.kt
@@ -665,7 +665,7 @@ class MusicApiServiceImpl(
         if (element.isJsonObject) {
             val obj = element.asJsonObject
             // 优先检查常见字段名
-            listOf("url", "picUrl", "coverImgUrl", "avatarUrl").firstNotNullOfOrNull { key ->
+            COMMON_URL_KEYS.firstNotNullOfOrNull { key ->
                 obj.get(key)?.takeIf { it.isJsonPrimitive }?.asString?.takeIf {
                     it.startsWith("http") && it.length > 12 && !it.contains("null")
                 }
@@ -677,5 +677,9 @@ class MusicApiServiceImpl(
             return element.asJsonArray.firstNotNullOfOrNull { findUrlRecursive(it) }
         }
         return null
+    }
+
+    companion object {
+        private val COMMON_URL_KEYS = listOf("url", "picUrl", "coverImgUrl", "avatarUrl")
     }
 }


### PR DESCRIPTION
Extracts the inline `listOf` string allocations in `MusicApiServiceImpl.kt`'s `findUrlRecursive` method to a class-level companion object constant `COMMON_URL_KEYS`. This targeted optimization prevents unnecessary list allocations on every recursive call, improving performance and memory efficiency when parsing JSON responses for URLs. Tests have been run and pass successfully.

---
*PR created automatically by Jules for task [2717156902362507121](https://jules.google.com/task/2717156902362507121) started by @Aurora-Nasa-1*