### PR TITLE
Fix infinite loop in UserViewModel when loading playlist tracks

### DIFF
--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -396,12 +396,19 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                     val allSongs = mutableListOf<Song>()
                     var offset = 0
                     val limit = 100
+                    val seenIds = mutableSetOf<String>()
                     while (true) {
                         val tracksBody = withContext(Dispatchers.IO) { api.getPlaylistTracks(playlistId, limit = limit, offset = offset) }
                         val songs = tracksBody.get("songs")?.asJsonArray?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
                         if (songs.isEmpty()) break
-                        allSongs.addAll(songs)
-                        if (songs.size < limit) break
+                        var addedNew = false
+                        for (song in songs) {
+                            if (seenIds.add(song.id)) {
+                                allSongs.add(song)
+                                addedNew = true
+                            }
+                        }
+                        if (!addedNew || songs.size < limit) break
                         offset += songs.size
                     }
 


### PR DESCRIPTION
Fixes an issue where `refreshPlaylistInBackground` could loop infinitely if the API continuously returns the same track page when `offset` is ignored.

---
*PR created automatically by Jules for task [12644813603335904714](https://jules.google.com/task/12644813603335904714) started by @Aurora-Nasa-1*