### PR TITLE
Refactor: Optimize Compose recompositions via `remember` for heavy instantiations

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -89,9 +90,11 @@ fun ContactItem(
     onClick: () -> Unit,
     onAvatarClick: () -> Unit
 ) {
-    val timeStr = contact.lastMessageTime?.let {
-        SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).format(Date(it))
-    } ?: ""
+    val timeStr = remember(contact.lastMessageTime) {
+        contact.lastMessageTime?.let {
+            SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).format(Date(it))
+        } ?: ""
+    }
 
     cp.player.ui.component.UnifiedListItem(
         onClick = { onClick() },

--- a/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
@@ -101,14 +101,22 @@ fun HealthScreenInline() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HealthTabRow(currentTab: Int, compact: Boolean = false, onSelect: (Int) -> Unit) {
-    val tabs = listOf(
-        stringResource(R.string.tab_overview) to Icons.Default.Dashboard,
-        stringResource(R.string.tab_methods) to Icons.Default.Analytics,
-        stringResource(R.string.tab_logs) to Icons.AutoMirrored.Filled.List,
-        stringResource(R.string.tab_test) to Icons.AutoMirrored.Filled.Send,
-        "apiMap" to Icons.Default.Map,
-        stringResource(R.string.tab_status) to Icons.Default.Info
-    )
+    val overviewStr = stringResource(R.string.tab_overview)
+    val methodsStr = stringResource(R.string.tab_methods)
+    val logsStr = stringResource(R.string.tab_logs)
+    val testStr = stringResource(R.string.tab_test)
+    val statusStr = stringResource(R.string.tab_status)
+
+    val tabs = remember(overviewStr, methodsStr, logsStr, testStr, statusStr) {
+        listOf(
+            overviewStr to Icons.Default.Dashboard,
+            methodsStr to Icons.Default.Analytics,
+            logsStr to Icons.AutoMirrored.Filled.List,
+            testStr to Icons.AutoMirrored.Filled.Send,
+            "apiMap" to Icons.Default.Map,
+            statusStr to Icons.Default.Info
+        )
+    }
     val chipSize = if (compact) 32.dp else 36.dp
     val iconSize = if (compact) 16.dp else 18.dp
 

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -202,16 +202,18 @@ fun SettingsScreen(
                         .padding(start = 16.dp, end = 8.dp, top = innerPadding.calculateTopPadding(), bottom = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    val navCategories = listOf(
-                        R.string.appearance to SettingsPage.Appearance,
-                        R.string.playback_quality_cat to SettingsPage.Audio,
-                        R.string.settings_ui_logic to SettingsPage.UiLogic,
-                        R.string.storage_cache to SettingsPage.StorageDownload,
-                        R.string.debug to SettingsPage.Debug,
-                        R.string.provider_management to SettingsPage.Provider,
-                        R.string.about to SettingsPage.About,
-                        R.string.sponsor to SettingsPage.Sponsor
-                    )
+                    val navCategories = remember {
+                        listOf(
+                            R.string.appearance to SettingsPage.Appearance,
+                            R.string.playback_quality_cat to SettingsPage.Audio,
+                            R.string.settings_ui_logic to SettingsPage.UiLogic,
+                            R.string.storage_cache to SettingsPage.StorageDownload,
+                            R.string.debug to SettingsPage.Debug,
+                            R.string.provider_management to SettingsPage.Provider,
+                            R.string.about to SettingsPage.About,
+                            R.string.sponsor to SettingsPage.Sponsor
+                        )
+                    }
                     navCategories.forEachIndexed { index, (titleRes, page) ->
                         ListItem(
                             headlineContent = { Text(stringResource(titleRes)) },


### PR DESCRIPTION
This PR provides targeted Jetpack Compose performance optimizations by correctly caching static or computationally heavy variables (e.g., `SimpleDateFormat`, `listOf`) inside `@Composable` functions using `remember`, minimizing garbage collection overhead during rapid recomposition phases.

---
*PR created automatically by Jules for task [4275012725817489089](https://jules.google.com/task/4275012725817489089) started by @Aurora-Nasa-1*