### PR TITLE
perf: Optimize UI formatting by hoisting thread-safe DateTimeFormatters

### DIFF
--- a/app/src/main/java/cp/player/ui/component/SongOptionsBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/SongOptionsBottomSheet.kt
@@ -39,6 +39,11 @@ import cp.player.api.MusicApiServiceFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val SONG_PUBLISH_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -303,8 +308,7 @@ fun SongOptionsBottomSheet(
                                                 // 发行时间
                                                 val publishTime = obj.get("publishTime")?.asLong ?: 0L
                                                 if (publishTime > 0) {
-                                                    val sdf = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
-                                                    map[context.getString(R.string.detail_publish_time)] = sdf.format(java.util.Date(publishTime))
+                                                    map[context.getString(R.string.detail_publish_time)] = SONG_PUBLISH_TIME_FORMATTER.format(Instant.ofEpochMilli(publishTime))
                                                 }
                                                 // 评论数
                                                 val commentCount = obj.get("commentCount")?.asLong ?: 0L

--- a/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
@@ -28,8 +28,11 @@ import cp.player.R
 import cp.player.model.Message
 import cp.player.util.resized
 import cp.player.ui.component.AppScaffold
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val CHAT_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -154,7 +157,7 @@ fun MessageBubble(
         RoundedCornerShape(20.dp, 20.dp, 20.dp, 4.dp)
     }
     val timeStr = remember(message.time) {
-        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(message.time))
+        CHAT_TIME_FORMATTER.format(Instant.ofEpochMilli(message.time))
     }
 
     Column(

--- a/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
@@ -23,8 +23,11 @@ import cp.player.R
 import cp.player.ui.component.AppScaffold
 import cp.player.model.Contact
 import cp.player.util.resized
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val CONTACT_TIME_FORMATTER = DateTimeFormatter.ofPattern("MM-dd HH:mm").withZone(ZoneId.systemDefault())
 
 @Composable
 fun ContactListScreen(
@@ -90,7 +93,7 @@ fun ContactItem(
     onAvatarClick: () -> Unit
 ) {
     val timeStr = contact.lastMessageTime?.let {
-        SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).format(Date(it))
+        CONTACT_TIME_FORMATTER.format(Instant.ofEpochMilli(it))
     } ?: ""
 
     cp.player.ui.component.UnifiedListItem(

--- a/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/HealthScreen.kt
@@ -43,6 +43,11 @@ import cp.player.ui.component.StyledModalBottomSheet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val HEALTH_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault())
 
 /**
  * 统一的健康状态与调试界面。
@@ -604,7 +609,7 @@ private fun CallRecordRow(record: HealthMonitor.ApiCallRecord, compact: Boolean)
     }
 
     val timeStr = remember(record.timestamp) {
-        java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.getDefault()).format(java.util.Date(record.timestamp))
+        HEALTH_TIME_FORMATTER.format(Instant.ofEpochMilli(record.timestamp))
     }
 
     Surface(

--- a/app/src/main/java/cp/player/util/LogManager.kt
+++ b/app/src/main/java/cp/player/util/LogManager.kt
@@ -4,14 +4,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 object LogManager {
     private val _logs = MutableStateFlow<List<LogEntry>>(emptyList())
     val logs: StateFlow<List<LogEntry>> = _logs.asStateFlow()
 
-    private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
+    private val dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
 
     data class LogEntry(
         val time: String,
@@ -27,7 +28,7 @@ object LogManager {
 
     fun log(level: String, message: String, throwable: Throwable? = null) {
         val entry = LogEntry(
-            time = dateFormat.format(Date()),
+            time = dateFormat.format(Instant.now()),
             level = level,
             message = message,
             throwable = throwable?.let { android.util.Log.getStackTraceString(it) }


### PR DESCRIPTION
This PR optimizes UI list performance by preventing repeated memory allocations for Date formatters on every list item and recomposition. It hoists them to file-level constants and migrates from `SimpleDateFormat` to the modern, thread-safe `DateTimeFormatter` (available since `minSdk` 28). It also resolves a subtle concurrency/thread-safety issue in `LogManager`.

---
*PR created automatically by Jules for task [16915794832481360142](https://jules.google.com/task/16915794832481360142) started by @Aurora-Nasa-1*