### PR TITLE
Fix ActivityNotFoundException crashes when launching intents

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
@@ -133,7 +133,11 @@ fun DownloadsContent(
                     manageStorageLauncher.launch(intent)
                 } catch (_: Exception) {
                     val intent = android.content.Intent(android.provider.Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-                    manageStorageLauncher.launch(intent)
+                    try {
+                        manageStorageLauncher.launch(intent)
+                    } catch (e: android.content.ActivityNotFoundException) {
+                        android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         } else {

--- a/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DspSettingsScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import cp.player.R
 import cp.player.engine.ExoAudioFxManager
 import cp.player.engine.RustEngine
 import cp.player.util.AutoEqParser
@@ -165,7 +166,13 @@ fun DspSettingsScreen(onNavigateBack: () -> Unit) {
                     )
                     Spacer(Modifier.weight(1f))
                     // 导入 AutoEQ
-                    IconButton(onClick = { launcher.launch("text/plain") }, modifier = Modifier.size(36.dp)) {
+                    IconButton(onClick = {
+                        try {
+                            launcher.launch("text/plain")
+                        } catch (e: android.content.ActivityNotFoundException) {
+                            android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                        }
+                    }, modifier = Modifier.size(36.dp)) {
                         Icon(Icons.Outlined.FolderOpen, "导入", modifier = Modifier.size(20.dp))
                     }
                     // 重置

--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -730,7 +730,13 @@ fun SettingsScreen(
                             ExpressiveClickItem(
                                 title = stringResource(R.string.download_dir),
                                 subtitle = downloadDir?.substringAfterLast("%2F") ?: stringResource(R.string.system_music_folder),
-                                onClick = { dirPicker.launch(null) },
+                                onClick = {
+                                    try {
+                                        dirPicker.launch(null)
+                                    } catch (e: android.content.ActivityNotFoundException) {
+                                        android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                                    }
+                                },
                                 shapes = ListItemDefaults.segmentedShapes(4, 6)
                             )
                             
@@ -929,7 +935,13 @@ fun SettingsScreen(
 
                             ExpressiveButtonItem(
                                 text = stringResource(R.string.import_new_module),
-                                onClick = { importLauncher.launch("application/zip") },
+                                onClick = {
+                                    try {
+                                        importLauncher.launch("application/zip")
+                                    } catch (e: android.content.ActivityNotFoundException) {
+                                        android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                                    }
+                                },
                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                 shapes = ListItemDefaults.segmentedShapes(currentProviders.size, currentProviders.size + 1)
@@ -950,7 +962,11 @@ fun SettingsScreen(
                                     },
                                     onUpdateZipSelected = {
                                         updatingProviderId = provider.id
-                                        updateLauncher.launch("application/zip")
+                                        try {
+                                            updateLauncher.launch("application/zip")
+                                        } catch (e: android.content.ActivityNotFoundException) {
+                                            android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                                        }
                                     },
                                     onSettingsSelected = {
                                         currentProviderSettingsId = provider.id

--- a/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SetupScreen.kt
@@ -209,7 +209,13 @@ fun SetupScreen(
                         Icon(Icons.Filled.ArrowForward, contentDescription = null)
                     }
                     OutlinedButton(
-                        onClick = { launcher.launch("application/zip") },
+                        onClick = {
+                            try {
+                                launcher.launch("application/zip")
+                            } catch (e: android.content.ActivityNotFoundException) {
+                                android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                            }
+                        },
                         modifier = Modifier.fillMaxWidth().height(56.dp),
                         shape = MaterialTheme.shapes.extraLarge
                     ) {
@@ -220,7 +226,13 @@ fun SetupScreen(
                     }
                 } else {
                     Button(
-                        onClick = { launcher.launch("application/zip") },
+                        onClick = {
+                            try {
+                                launcher.launch("application/zip")
+                            } catch (e: android.content.ActivityNotFoundException) {
+                                android.widget.Toast.makeText(context, context.getString(R.string.no_suitable_app_found), android.widget.Toast.LENGTH_SHORT).show()
+                            }
+                        },
                         modifier = Modifier.fillMaxWidth().height(64.dp),
                         shape = MaterialTheme.shapes.extraLarge
                     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -600,4 +600,5 @@
     <string name="quality_playlists">精品歌单</string>
     <string name="view_more">查看更多</string>
 
+    <string name="no_suitable_app_found">未找到支持该操作的应用</string>
 </resources>


### PR DESCRIPTION
This commit prevents fatal crashes on devices (e.g. TVs, AOSP builds, custom ROMs) that lack built-in file managers or settings activities by safely catching `ActivityNotFoundException` when launching `ActivityResultLauncher` intents.

---
*PR created automatically by Jules for task [12153891319890695270](https://jules.google.com/task/12153891319890695270) started by @Aurora-Nasa-1*