### PR TITLE
Fix ActivityNotFoundException when launching dir picker without a file manager

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/SettingsScreen.kt
@@ -730,7 +730,17 @@ fun SettingsScreen(
                             ExpressiveClickItem(
                                 title = stringResource(R.string.download_dir),
                                 subtitle = downloadDir?.substringAfterLast("%2F") ?: stringResource(R.string.system_music_folder),
-                                onClick = { dirPicker.launch(null) },
+                                onClick = {
+                                    try {
+                                        dirPicker.launch(null)
+                                    } catch (e: android.content.ActivityNotFoundException) {
+                                        android.widget.Toast.makeText(
+                                            context,
+                                            context.getString(R.string.no_file_manager_found),
+                                            android.widget.Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
+                                },
                                 shapes = ListItemDefaults.segmentedShapes(4, 6)
                             )
                             

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="add_songs_count">添加 %1$d 首歌曲</string>
 
     <!-- 登录 -->
+    <string name="no_file_manager_found">未找到文件管理器</string>
     <string name="add_new_account">添加新账号</string>
     <string name="other_provider_accounts">其他提供商账号</string>
 


### PR DESCRIPTION
Fix ActivityNotFoundException when launching dir picker without a file manager

Wrapped `dirPicker.launch(null)` with a try-catch block catching `ActivityNotFoundException` in `SettingsScreen.kt`. This prevents the application from crashing on devices (like TVs or custom ROMs) that do not have a built-in file manager installed. Also added a localized string `no_file_manager_found` to display a toast message indicating the issue gracefully to the user.

---
*PR created automatically by Jules for task [13831282882099172208](https://jules.google.com/task/13831282882099172208) started by @Aurora-Nasa-1*