### PR TITLE
Optimize date formatting performance in lists

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
@@ -28,8 +28,12 @@ import cp.player.R
 import cp.player.model.Message
 import cp.player.util.resized
 import cp.player.ui.component.AppScaffold
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.*
+
+private val messageTimeFormatter = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -154,7 +158,7 @@ fun MessageBubble(
         RoundedCornerShape(20.dp, 20.dp, 20.dp, 4.dp)
     }
     val timeStr = remember(message.time) {
-        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(message.time))
+        messageTimeFormatter.format(Instant.ofEpochMilli(message.time))
     }
 
     Column(

--- a/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
@@ -23,8 +23,12 @@ import cp.player.R
 import cp.player.ui.component.AppScaffold
 import cp.player.model.Contact
 import cp.player.util.resized
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.*
+
+private val contactTimeFormatter = DateTimeFormatter.ofPattern("MM-dd HH:mm").withZone(ZoneId.systemDefault())
 
 @Composable
 fun ContactListScreen(
@@ -90,7 +94,7 @@ fun ContactItem(
     onAvatarClick: () -> Unit
 ) {
     val timeStr = contact.lastMessageTime?.let {
-        SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).format(Date(it))
+        contactTimeFormatter.format(Instant.ofEpochMilli(it))
     } ?: ""
 
     cp.player.ui.component.UnifiedListItem(


### PR DESCRIPTION
Replaced `SimpleDateFormat` instantiations inside `@Composable`s with single, file-level `DateTimeFormatter` instances in list UIs to improve scrolling performance and reduce GC overhead.

---
*PR created automatically by Jules for task [18333848803224551338](https://jules.google.com/task/18333848803224551338) started by @Aurora-Nasa-1*