### PR TITLE
Fix IllegalStateException in Compose Navigation

### DIFF
--- a/app/src/main/java/cp/player/MainActivity.kt
+++ b/app/src/main/java/cp/player/MainActivity.kt
@@ -228,10 +228,12 @@ fun AppNavigation(
                             label = { Text(label) },
                             selected = isSelected,
                             onClick = {
-                                navController.navigate(route) {
-                                    popUpTo("main") { saveState = true }
-                                    launchSingleTop = true
-                                    restoreState = true
+                                if (!isSelected) {
+                                    navController.navigate(route) {
+                                        popUpTo("main") { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
                                 }
                             },
                             colors = NavigationBarItemDefaults.colors(
@@ -994,10 +996,12 @@ fun AppMainContent(
                     navItems = navItems,
                     currentRoute = currentDestination?.route,
                     onNavigate = { route ->
-                        navController.navigate(route) {
-                            popUpTo("main") { saveState = true }
-                            launchSingleTop = true
-                            restoreState = true
+                        if (route != currentDestination?.route) {
+                            navController.navigate(route) {
+                                popUpTo("main") { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
                         }
                     },
                     modifier = Modifier


### PR DESCRIPTION
Fixes Sentry Issue [ANDROID-13] where rapid double clicks on NavigationBarItems or the NavigationCapsule cause the navigation stack to become out of sync, leading to a crash when popping the backstack.

---
*PR created automatically by Jules for task [6784401672663580714](https://jules.google.com/task/6784401672663580714) started by @Aurora-Nasa-1*