### PR TITLE
fix: prevent compose duplicate key crashes and viewmodel infinite loops

### DIFF
--- a/app/src/main/java/cp/player/ui/component/AddToPlaylistBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/AddToPlaylistBottomSheet.kt
@@ -40,7 +40,7 @@ fun AddToPlaylistBottomSheet(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                itemsIndexed(ownedPlaylists, key = { _, p -> p.id }) { index, p ->
+                itemsIndexed(ownedPlaylists, key = { index, p -> "${p.id}_$index" }) { index, p ->
                     PlaylistItem(
                         playlist = p,
                         onClick = { onPlaylistSelected(p) },

--- a/app/src/main/java/cp/player/ui/component/CommentPage.kt
+++ b/app/src/main/java/cp/player/ui/component/CommentPage.kt
@@ -118,7 +118,7 @@ fun CommentPage(
         ) {
             if (currentSort == 1) {
                 // 最热排序：显示热门评论
-                itemsIndexed(hotComments, key = { _, c -> "hot_${c.id}" }) { _, comment ->
+                itemsIndexed(hotComments, key = { index, c -> "hot_${c.id}_$index" }) { _, comment ->
                     CommentItem(
                         comment = comment,
                         onLikeClick = { onLikeClick(comment) },
@@ -129,7 +129,7 @@ fun CommentPage(
                 }
             } else {
                 // 最新排序：显示最新评论
-                itemsIndexed(newestComments, key = { _, c -> "new_${c.id}" }) { _, comment ->
+                itemsIndexed(newestComments, key = { index, c -> "new_${c.id}_$index" }) { _, comment ->
                     CommentItem(
                         comment = comment,
                         onLikeClick = { onLikeClick(comment) },

--- a/app/src/main/java/cp/player/ui/component/FloorCommentBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/FloorCommentBottomSheet.kt
@@ -115,7 +115,7 @@ fun FloorCommentBottomSheet(
                         }
 
                         // 回复列表
-                        itemsIndexed(replies, key = { _, it -> it.id }) { _, comment ->
+                        itemsIndexed(replies, key = { index, it -> "${it.id}_$index" }) { _, comment ->
                             CommentItem(
                                 comment = comment,
                                 onLikeClick = { onLikeClick(comment) },

--- a/app/src/main/java/cp/player/ui/component/SourceSongsSelectionBottomSheet.kt
+++ b/app/src/main/java/cp/player/ui/component/SourceSongsSelectionBottomSheet.kt
@@ -92,7 +92,7 @@ fun SourceSongsSelectionBottomSheet(
                     contentPadding = PaddingValues(bottom = 80.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    itemsIndexed(songs!!, key = { _, s -> s.id }) { index, s ->
+                    itemsIndexed(songs!!, key = { index, s -> "${s.id}_$index" }) { index, s ->
                         val isSelected = selectedSongs.contains(s.id)
                         SongItem(
                             song = s,

--- a/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/CloudMusicScreen.kt
@@ -54,7 +54,7 @@ fun CloudMusicContent(
                 ),
                 verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                itemsIndexed(songs, key = { _, song -> song.id }) { index, song ->
+                itemsIndexed(songs, key = { index, song -> "${song.id}_$index" }) { index, song ->
                     SongItem(
                         song = song,
                         isFavorite = favoriteSongs.contains(song.id),

--- a/app/src/main/java/cp/player/ui/screen/DiscoveryScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DiscoveryScreen.kt
@@ -104,7 +104,7 @@ fun DiscoveryScreen(
                     Spacer(modifier = Modifier.height(24.dp))
                     SectionHeader(title = stringResource(R.string.recommended_new_songs))
                 }
-                itemsIndexed(personalizedNewSongs) { index, song ->
+                itemsIndexed(personalizedNewSongs, key = { index, song -> "${song.id}_$index" }) { index, song ->
                     SongItem(
                         song = song,
                         index = index,
@@ -125,7 +125,7 @@ fun DiscoveryScreen(
                         onAction = onViewAllTopSongs
                     )
                 }
-                itemsIndexed(topSongs.take(10)) { index, song ->
+                itemsIndexed(topSongs.take(10), key = { index, song -> "${song.id}_$index" }) { index, song ->
                     SongItem(
                         song = song,
                         index = index,

--- a/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/DownloadsScreen.kt
@@ -384,7 +384,7 @@ private fun DownloadsMainContent(
                 val downloadingTasks = tasks.values.filter { it.status != DownloadStatus.COMPLETED }.toList()
                 if (downloadingTasks.isNotEmpty()) {
                     item { Text(stringResource(R.string.downloading), style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(top = 8.dp, bottom = 8.dp, start = 16.dp)) }
-                    itemsIndexed(downloadingTasks, key = { _, task -> task.song.id }) { index, task ->
+                    itemsIndexed(downloadingTasks, key = { index, task -> "${task.song.id}_$index" }) { index, task ->
                         SongItem(
                             song = task.song,
                             isFavorite = false,
@@ -427,7 +427,7 @@ private fun DownloadsMainContent(
                 val validDownloadedSongs = downloadedSongs.distinctBy { it.song.id }
                 if (validDownloadedSongs.isNotEmpty()) {
                     item { Text(stringResource(R.string.downloaded), style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp, start = 16.dp)) }
-                    itemsIndexed(validDownloadedSongs, key = { _, metadata -> metadata.song.id }) { index, metadata ->
+                    itemsIndexed(validDownloadedSongs, key = { index, metadata -> "${metadata.song.id}_$index" }) { index, metadata ->
                         val uri = if (metadata.filePath?.startsWith("content://") == true) {
                             android.net.Uri.parse(metadata.filePath)
                         } else {
@@ -591,7 +591,7 @@ private fun DownloadsMainContent(
                         }
                     }
 
-                    itemsIndexed(sortedLocalSongs, key = { _, it -> it.songId }) { index, localSong ->
+                    itemsIndexed(sortedLocalSongs, key = { index, it -> "${it.songId}_$index" }) { index, localSong ->
                         val uri = android.net.Uri.parse(localSong.albumArtUrl)
 
                         // 获取封面：云端绑定封面 > 预提取封面 > 内嵌封面 > null

--- a/app/src/main/java/cp/player/ui/screen/PlaylistDetailScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/PlaylistDetailScreen.kt
@@ -571,7 +571,7 @@ private fun PlaylistDetailContent(
                 }
             }
 
-            itemsIndexed(items = songs, key = { _, song -> song.id }) { index, song ->
+            itemsIndexed(items = songs, key = { index, song -> "${song.id}_$index" }) { index, song ->
                 if (index >= songs.size - 5 && hasMoreSongs && !isFetchingMore) {
                     LaunchedEffect(index) {
                         onLoadMore()

--- a/app/src/main/java/cp/player/ui/screen/RankingDetailScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/RankingDetailScreen.kt
@@ -103,7 +103,7 @@ fun RankingDetailScreen(
                     }
                 }
             } else {
-                itemsIndexed(songs) { index, song ->
+                itemsIndexed(songs, key = { index, song -> "${song.id}_$index" }) { index, song ->
                     SongItem(
                         song = song,
                         index = index + 1,

--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -394,14 +394,21 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                     }
 
                     val allSongs = mutableListOf<Song>()
+                    val seenIds = mutableSetOf<String>()
                     var offset = 0
                     val limit = 100
                     while (true) {
                         val tracksBody = withContext(Dispatchers.IO) { api.getPlaylistTracks(playlistId, limit = limit, offset = offset) }
                         val songs = tracksBody.get("songs")?.asJsonArray?.mapNotNull { JsonUtils.parseSong(it) } ?: emptyList()
                         if (songs.isEmpty()) break
-                        allSongs.addAll(songs)
-                        if (songs.size < limit) break
+                        var addedNew = false
+                        for (song in songs) {
+                            if (seenIds.add(song.id)) {
+                                allSongs.add(song)
+                                addedNew = true
+                            }
+                        }
+                        if (!addedNew || songs.size < limit) break
                         offset += songs.size
                     }
 


### PR DESCRIPTION
Fixes two bugs:
1. `IllegalArgumentException` duplicate key crashes in Compose Lazy layouts by adding composite keys (`${id}_$index`) to `itemsIndexed` usages.
2. Infinite loops in `UserViewModel.kt`'s paginated API requests by keeping track of `seenIds` and breaking the loop if no new elements are returned.

---
*PR created automatically by Jules for task [8518151768416139804](https://jules.google.com/task/8518151768416139804) started by @Aurora-Nasa-1*