### PR TITLE
Refactor SimpleDateFormat usage to DateTimeFormatter for performance and thread safety

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
@@ -28,8 +28,11 @@ import cp.player.R
 import cp.player.model.Message
 import cp.player.util.resized
 import cp.player.ui.component.AppScaffold
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val dateFormat = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -154,7 +157,7 @@ fun MessageBubble(
         RoundedCornerShape(20.dp, 20.dp, 20.dp, 4.dp)
     }
     val timeStr = remember(message.time) {
-        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(message.time))
+        dateFormat.format(Instant.ofEpochMilli(message.time))
     }
 
     Column(

--- a/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ContactListScreen.kt
@@ -23,8 +23,11 @@ import cp.player.R
 import cp.player.ui.component.AppScaffold
 import cp.player.model.Contact
 import cp.player.util.resized
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val dateFormat = DateTimeFormatter.ofPattern("MM-dd HH:mm").withZone(ZoneId.systemDefault())
 
 @Composable
 fun ContactListScreen(
@@ -90,7 +93,7 @@ fun ContactItem(
     onAvatarClick: () -> Unit
 ) {
     val timeStr = contact.lastMessageTime?.let {
-        SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).format(Date(it))
+        dateFormat.format(Instant.ofEpochMilli(it))
     } ?: ""
 
     cp.player.ui.component.UnifiedListItem(

--- a/app/src/main/java/cp/player/util/LogManager.kt
+++ b/app/src/main/java/cp/player/util/LogManager.kt
@@ -4,14 +4,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 object LogManager {
     private val _logs = MutableStateFlow<List<LogEntry>>(emptyList())
     val logs: StateFlow<List<LogEntry>> = _logs.asStateFlow()
 
-    private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
+    private val dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
 
     data class LogEntry(
         val time: String,
@@ -27,7 +29,7 @@ object LogManager {
 
     fun log(level: String, message: String, throwable: Throwable? = null) {
         val entry = LogEntry(
-            time = dateFormat.format(Date()),
+            time = dateFormat.format(Instant.now()),
             level = level,
             message = message,
             throwable = throwable?.let { android.util.Log.getStackTraceString(it) }


### PR DESCRIPTION
I've targeted specific parts of the UI (ContactListScreen, ChatScreen) and the logger (LogManager) where `SimpleDateFormat` was either causing unnecessary object allocations during Jetpack Compose recomposition or exhibiting thread-safety issues. By swapping it out and properly hoisting the new `DateTimeFormatter`, we prevent garbage collection hiccups during UI scrolling and eliminate logging concurrency bugs. All tests have passed.

---
*PR created automatically by Jules for task [5229174573193548655](https://jules.google.com/task/5229174573193548655) started by @Aurora-Nasa-1*