### PR TITLE
Fix LazyColumn duplicate key crash in ChatScreen

### DIFF
--- a/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
+++ b/app/src/main/java/cp/player/ui/screen/ChatScreen.kt
@@ -128,7 +128,7 @@ fun ChatScreen(
         ) {
             items(
                 items = messages,
-                key = { it.hashCode() }
+                key = { it.id }
             ) { message ->
                 MessageBubble(
                     message = message,


### PR DESCRIPTION
Fixes the Sentry bug: [ANDROID-16] IllegalArgumentException: Key "1836077167" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.

---
*PR created automatically by Jules for task [5811824898046405752](https://jules.google.com/task/5811824898046405752) started by @Aurora-Nasa-1*