### PR TITLE
Fix Compose LazyList duplicate key crash by deduplicating upstream

### DIFF
--- a/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/cp/player/viewmodel/UserViewModel.kt
@@ -202,7 +202,7 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
         isPlaylistLoading = false
 
         currentPlaylistMetadata = playlist
-        playlistSongs = songs
+        playlistSongs = songs.distinctBy { it.id }
     }
 
     /**
@@ -346,7 +346,7 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                         playlistSongsOffset += songs.size
                         // 防止用户已切换歌单时覆盖新歌单数据
                         if (fetchingPlaylistId == playlistId) {
-                            playlistSongs = if (isLoadMore) playlistSongs + songs else songs
+                            playlistSongs = (if (isLoadMore) playlistSongs + songs else songs).distinctBy { it.id }
                         }
                     } else if (!isLoadMore) {
                         if (fetchingPlaylistId == playlistId) {
@@ -417,7 +417,7 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                         withContext(Dispatchers.Main) {
                             // 仅在用户仍在此歌单时更新歌曲列表
                             if (fetchingPlaylistId == playlistId || fetchingPlaylistId == null) {
-                                playlistSongs = allSongs
+                                playlistSongs = allSongs.distinctBy { it.id }
                                 playlistSongsOffset = allSongs.size
                                 hasMorePlaylistSongs = false
 
@@ -582,7 +582,7 @@ class UserViewModel(application: Application) : BaseViewModel(application) {
                     }
                 }
 
-                cloudSongs = allSongs
+                cloudSongs = allSongs.distinctBy { it.id }
 
                 // Extract simpleSong.id and bind it
                 withContext(Dispatchers.IO) {


### PR DESCRIPTION
Fixes Sentry Issue [ANDROID-17] `IllegalArgumentException: Key was already used`.

**Root Cause:**
When a `LazyColumn` or `LazyRow` defines a key via `itemsIndexed(..., key = { _, item -> item.id })`, Jetpack Compose strictly requires uniqueness to correctly dispatch layout animations and recompositions. If the backing data model (e.g., `playlistSongs` in `UserViewModel`) contains duplicate songs, a crash occurs. This usually happens during `offset`-based pagination (where a provider's shifting indices cause the same song to be returned on page 1 and page 2), or when combining cached local data with fresh network responses.

**Solution:**
Deduplicated the data at the source (`UserViewModel.kt`) whenever `playlistSongs` or `cloudSongs` are mutated or appended. This guarantees safe key assignments downstream in `PlaylistDetailScreen`, `CloudMusicScreen`, etc., and avoids imposing UI-thread filtering penalties on every layout measure pass.

---
*PR created automatically by Jules for task [9411432152499881480](https://jules.google.com/task/9411432152499881480) started by @Aurora-Nasa-1*