### PR TITLE
Fix OutOfMemoryError during theme color extraction

### DIFF
--- a/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
+++ b/app/src/main/java/cp/player/usecase/MediaMetadataUseCase.kt
@@ -33,11 +33,12 @@ class MediaMetadataUseCase(private val application: Application) {
             val loader = SingletonImageLoader.get(application)
             val request = ImageRequest.Builder(application)
                 .data(resizedUrl)
+                .size(128)
                 .allowHardware(false)
                 .build()
             val result = loader.execute(request)
             if (result is SuccessResult) {
-                val bitmap = result.image.toBitmap()
+                val bitmap = result.image.toBitmap(128, 128)
 
                 // Fallback using Palette in case MCU fails
                 var fallbackColor = 0


### PR DESCRIPTION
Fix OutOfMemoryError during theme color extraction by strictly sizing memory allocations for cover arts down to 128x128 using Coil, averting large 36MB memory allocations.

---
*PR created automatically by Jules for task [8013862397780395255](https://jules.google.com/task/8013862397780395255) started by @Aurora-Nasa-1*